### PR TITLE
Switch Deployment Repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Apparently, Sonatype didn't want to give us access to `s01.oss.` since we already requested access to `oss.`. Therefore, this PR switches to the "legacy" deployment repository.
I made sure that my personal credentials now work for the repository.