### PR TITLE
Fix Exception if Root Directory Does Not Exist

### DIFF
--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
@@ -63,6 +63,12 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
     public List<ServiceBinding> getServiceBindings()
     {
         logger.debug("Trying to read service bindings from '{}'.", rootPath);
+
+        if (!Files.exists(rootPath) || !Files.isDirectory(rootPath)) {
+            logger.debug("Skipping '{}': Directory does not exist.", rootPath);
+            return Collections.emptyList();
+        }
+
         try (final Stream<Path> files = Files.list(rootPath)) {
             return files.filter(Files::isDirectory).flatMap(this::parseServiceBindings).collect(Collectors.toList());
         } catch (final SecurityException | IOException e) {


### PR DESCRIPTION
This PR fixes an issue, which leads to a `FileNotFoundException` in case the service binding root directory (for the `SapServiceOperatorLayeredServiceBindingAccessor`) does not exist.