### PR TITLE
Fix: Parsing JSON Objects in the `ServiceBindingIoAccessor`

### DIFF
--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -248,7 +249,7 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
 
         if( !property.isContainer() ) {
             // property is not a container, so the content should be attached as a flat value
-            properties.put(property.getName(), jsonObject.get("content"));
+            properties.put(property.getName(), getJsonProperty(jsonObject, "content"));
             return;
         }
 
@@ -260,8 +261,24 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
         }
 
         for( final String key : content.keySet() ) {
-            properties.put(key, content.get(key));
+            properties.put(key, getJsonProperty(content, key));
         }
+    }
+
+    @Nullable
+    private Object getJsonProperty( @Nonnull final JSONObject jsonObject, @Nonnull final String key )
+    {
+        final Object property = jsonObject.get(key);
+
+        if( property instanceof JSONObject ) {
+            return ((JSONObject) property).toMap();
+        }
+
+        if( property instanceof JSONArray ) {
+            return ((JSONArray) property).toList();
+        }
+
+        return property;
     }
 
     @Nonnull

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessorTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessorTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -419,6 +420,7 @@ class SapServiceOperatorServiceBindingIoAccessorTest
         assertThat(dataXsuaaBinding.getCredentials().get("domains"))
             .asList()
             .containsExactlyInAnyOrder("data-xsuaa-domain-1", "data-xsuaa-domain-2");
+        assertThat(dataXsuaaBinding.getCredentials().get("uaa")).isInstanceOf(Map.class);
     }
 
     private static void assertContainsSecretKeyXsuaaBinding( @Nonnull final List<ServiceBinding> serviceBindings )

--- a/sap-service-operator/src/test/resources/SapServiceOperatorServiceBindingIoAccessorTest/PartiallyValidMixedBindings/data-xsuaa-binding/.metadata
+++ b/sap-service-operator/src/test/resources/SapServiceOperatorServiceBindingIoAccessorTest/PartiallyValidMixedBindings/data-xsuaa-binding/.metadata
@@ -35,6 +35,10 @@
         {
             "name": "domains",
             "format": "json"
+        },
+        {
+            "name": "uaa",
+            "format": "json"
         }
     ]
 }

--- a/sap-service-operator/src/test/resources/SapServiceOperatorServiceBindingIoAccessorTest/PartiallyValidMixedBindings/data-xsuaa-binding/uaa
+++ b/sap-service-operator/src/test/resources/SapServiceOperatorServiceBindingIoAccessorTest/PartiallyValidMixedBindings/data-xsuaa-binding/uaa
@@ -1,0 +1,35 @@
+{
+  "text": "text",
+  "number": 13.37,
+  "bool": true,
+  "list": [
+    "some item",
+    4.2,
+    false,
+    {
+      "text-in-object-in-list": "text-in-object-in-list",
+      "number-in-object-in-list": 99.9,
+      "bool-in-object-in-list": false
+    },
+    [
+      "text in list in list",
+      0.01,
+      true
+    ]
+  ],
+  "object": {
+    "text-in-object": "some entry",
+    "number-in-object": -73.31,
+    "bool-in-object": true,
+    "object-in-object": {
+      "text-in-object-in-object": "text-in-object-in-object",
+      "number-in-object-in-object": -12.34,
+      "bool-in-object-in-object": false
+    },
+    "list-in-object": [
+      "text in list in object",
+      -33.33,
+      true
+    ]
+  }
+}

--- a/sap-service-operator/src/test/resources/SapServiceOperatorServiceBindingIoAccessorTest/ValidMixedBindings/data-xsuaa-binding/.metadata
+++ b/sap-service-operator/src/test/resources/SapServiceOperatorServiceBindingIoAccessorTest/ValidMixedBindings/data-xsuaa-binding/.metadata
@@ -35,6 +35,10 @@
         {
             "name": "domains",
             "format": "json"
+        },
+        {
+            "name": "uaa",
+            "format": "json"
         }
     ]
 }

--- a/sap-service-operator/src/test/resources/SapServiceOperatorServiceBindingIoAccessorTest/ValidMixedBindings/data-xsuaa-binding/uaa
+++ b/sap-service-operator/src/test/resources/SapServiceOperatorServiceBindingIoAccessorTest/ValidMixedBindings/data-xsuaa-binding/uaa
@@ -1,0 +1,35 @@
+{
+  "text": "text",
+  "number": 13.37,
+  "bool": true,
+  "list": [
+    "some item",
+    4.2,
+    false,
+    {
+      "text-in-object-in-list": "text-in-object-in-list",
+      "number-in-object-in-list": 99.9,
+      "bool-in-object-in-list": false
+    },
+    [
+      "text in list in list",
+      0.01,
+      true
+    ]
+  ],
+  "object": {
+    "text-in-object": "some entry",
+    "number-in-object": -73.31,
+    "bool-in-object": true,
+    "object-in-object": {
+      "text-in-object-in-object": "text-in-object-in-object",
+      "number-in-object-in-object": -12.34,
+      "bool-in-object-in-object": false
+    },
+    "list-in-object": [
+      "text in list in object",
+      -33.33,
+      true
+    ]
+  }
+}


### PR DESCRIPTION
This PR fixes an issue with the `SapServiceOperatorServiceBindingIoAccessor` where JSON object properties would cause an `UnsupportedPropertyTypeException` when creating the `ServiceBinding` instance.