### PR TITLE
Feat: Introduce Filesystem-Aware Caching in the SAP BTP Operator Accessors

### DIFF
--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/DirectoryBasedCache.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/DirectoryBasedCache.java
@@ -4,12 +4,9 @@
 
 package com.sap.cloud.environment.servicebinding;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
@@ -20,10 +17,4 @@ interface DirectoryBasedCache
 {
     @Nonnull
     List<ServiceBinding> getServiceBindings( @Nonnull final Collection<Path> directories );
-
-    @Nonnull
-    default List<ServiceBinding> getServiceBindings( @Nonnull final Stream<Path> directories )
-    {
-        return getServiceBindings(directories.filter(Files::isDirectory).collect(Collectors.toList()));
-    }
 }

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/DirectoryBasedCache.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/DirectoryBasedCache.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved.
+ */
+
+package com.sap.cloud.environment.servicebinding;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+
+@FunctionalInterface
+interface DirectoryBasedCache
+{
+    @Nonnull
+    List<ServiceBinding> getServiceBindings( @Nonnull final Collection<Path> directories );
+
+    @Nonnull
+    default List<ServiceBinding> getServiceBindings( @Nonnull final Stream<Path> directories )
+    {
+        return getServiceBindings(directories.filter(Files::isDirectory).collect(Collectors.toList()));
+    }
+}

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved.
+ */
+
+package com.sap.cloud.environment.servicebinding;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+class FileSystemWatcherCache implements DirectoryBasedCache
+{
+    @Nonnull
+    private static final Collection<WatchEvent.Kind<?>> MODIFICATION_EVENTS =
+        Arrays.asList(ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+
+    @Nonnull
+    private final Function<Path, ServiceBinding> serviceBindingLoader;
+    @Nonnull
+    private final Map<Path, ServiceBinding> cachedServiceBindings = new HashMap<>();
+    @Nonnull
+    private final Map<Path, WatchKey> directoryWatchKeys = new HashMap<>();
+    @Nonnull
+    private final WatchService watchService;
+
+    public FileSystemWatcherCache( @Nonnull final Function<Path, ServiceBinding> serviceBindingLoader )
+    {
+        this.serviceBindingLoader = serviceBindingLoader;
+
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+        }
+        catch( final IOException e ) {
+            throw new IllegalStateException(
+                String.format("Unable to create new instance of '%s'.", WatchService.class.getSimpleName()),
+                e);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public synchronized List<ServiceBinding> getServiceBindings( @Nonnull final Collection<Path> directories )
+    {
+        removeOutdatedWatchKeys(directories);
+        removeOutdatedServiceBindings(directories);
+        return directories
+            .stream()
+            .peek(this::renewCachedServiceBindingIfNeeded)
+            .map(cachedServiceBindings::get)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
+
+    private void removeOutdatedWatchKeys( @Nonnull final Collection<Path> directoriesOfInterest )
+    {
+        for( final Map.Entry<Path, WatchKey> entry : directoryWatchKeys.entrySet() ) {
+            if( directoriesOfInterest.contains(entry.getKey()) ) {
+                continue;
+            }
+
+            entry.getValue().cancel();
+            directoryWatchKeys.remove(entry.getKey());
+        }
+    }
+
+    private void removeOutdatedServiceBindings( @Nonnull final Collection<Path> directoriesOfInterest )
+    {
+        for( final Map.Entry<Path, ServiceBinding> entry : cachedServiceBindings.entrySet() ) {
+            if( directoriesOfInterest.contains(entry.getKey()) ) {
+                continue;
+            }
+
+            cachedServiceBindings.remove(entry.getKey());
+        }
+    }
+
+    private void renewCachedServiceBindingIfNeeded( @Nonnull final Path directory )
+    {
+        @Nullable
+        final WatchKey watchKey = directoryWatchKeys.get(directory);
+        if( watchKey == null ) {
+            watchAndCacheServiceBinding(directory);
+            return;
+        }
+
+        if( !watchKey.isValid() ) {
+            throw new IllegalStateException(
+                String.format("%s for directory '%s' is invalid.", WatchKey.class.getSimpleName(), directory));
+        }
+
+        if( hasBeenModified(watchKey) ) {
+            cacheServiceBinding(directory);
+        }
+    }
+
+    private void watchAndCacheServiceBinding( @Nonnull final Path directory )
+    {
+        startWatching(directory);
+        cacheServiceBinding(directory);
+    }
+
+    private void cacheServiceBinding( @Nonnull final Path directory )
+    {
+        cachedServiceBindings.remove(directory);
+
+        @Nullable
+        final ServiceBinding serviceBinding = serviceBindingLoader.apply(directory);
+        if( serviceBinding == null ) {
+            return;
+        }
+
+        cachedServiceBindings.put(directory, serviceBinding);
+    }
+
+    private void startWatching( @Nonnull final Path directory )
+    {
+        try {
+            final WatchKey watchKey = directory.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+            directoryWatchKeys.put(directory, watchKey);
+        }
+        catch( final IOException e ) {
+            throw new IllegalStateException(String.format("Unable to watch directory '%s'.", directory), e);
+        }
+    }
+
+    private boolean hasBeenModified( @Nonnull final WatchKey watchKey )
+    {
+        final List<WatchEvent<?>> events = watchKey.pollEvents();
+        watchKey.reset();
+
+        return events.stream().map(WatchEvent::kind).anyMatch(MODIFICATION_EVENTS::contains);
+    }
+}

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
@@ -75,25 +75,19 @@ class FileSystemWatcherCache implements DirectoryBasedCache
 
     private void removeOutdatedWatchKeys( @Nonnull final Collection<Path> directoriesOfInterest )
     {
-        for( final Map.Entry<Path, WatchKey> entry : directoryWatchKeys.entrySet() ) {
+        directoryWatchKeys.entrySet().removeIf(entry -> {
             if( directoriesOfInterest.contains(entry.getKey()) ) {
-                continue;
+                return false;
             }
 
             entry.getValue().cancel();
-            directoryWatchKeys.remove(entry.getKey());
-        }
+            return true;
+        });
     }
 
     private void removeOutdatedServiceBindings( @Nonnull final Collection<Path> directoriesOfInterest )
     {
-        for( final Map.Entry<Path, ServiceBinding> entry : cachedServiceBindings.entrySet() ) {
-            if( directoriesOfInterest.contains(entry.getKey()) ) {
-                continue;
-            }
-
-            cachedServiceBindings.remove(entry.getKey());
-        }
+        cachedServiceBindings.entrySet().removeIf(entry -> !directoriesOfInterest.contains(entry.getKey()));
     }
 
     private void renewCachedServiceBindingIfNeeded( @Nonnull final Path directory )

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
@@ -37,10 +37,10 @@ class FileSystemWatcherCache implements DirectoryBasedCache
     @Nonnull
     private final Function<Path, ServiceBinding> serviceBindingLoader;
     @Nonnull
-    // internal for simplified testing
+    // package-private for simplified testing
     final Map<Path, ServiceBinding> cachedServiceBindings = new HashMap<>();
     @Nonnull
-    // internal for simplified testing
+    // package-private for simplified testing
     final Map<Path, WatchKey> directoryWatchKeys = new HashMap<>();
     @Nonnull
     private final WatchService watchService;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
@@ -37,9 +37,11 @@ class FileSystemWatcherCache implements DirectoryBasedCache
     @Nonnull
     private final Function<Path, ServiceBinding> serviceBindingLoader;
     @Nonnull
-    private final Map<Path, ServiceBinding> cachedServiceBindings = new HashMap<>();
+    // internal for simplified testing
+    final Map<Path, ServiceBinding> cachedServiceBindings = new HashMap<>();
     @Nonnull
-    private final Map<Path, WatchKey> directoryWatchKeys = new HashMap<>();
+    // internal for simplified testing
+    final Map<Path, WatchKey> directoryWatchKeys = new HashMap<>();
     @Nonnull
     private final WatchService watchService;
 

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
@@ -87,7 +87,7 @@ class FileSystemWatcherCache implements DirectoryBasedCache
 
     private void removeOutdatedServiceBindings( @Nonnull final Collection<Path> directoriesOfInterest )
     {
-        cachedServiceBindings.entrySet().removeIf(entry -> !directoriesOfInterest.contains(entry.getKey()));
+        cachedServiceBindings.keySet().removeIf(key -> !directoriesOfInterest.contains(key));
     }
 
     private void renewCachedServiceBindingIfNeeded( @Nonnull final Path directory )

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -151,7 +152,7 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
     @Nonnull
     private List<ServiceBinding> parseServiceBindings( @Nonnull final Stream<Path> servicePaths )
     {
-        return cache.getServiceBindings(servicePaths.flatMap(servicePath -> {
+        final List<Path> serviceBindingRoots = servicePaths.flatMap(servicePath -> {
             try {
                 return Files.list(servicePath);
             }
@@ -160,7 +161,8 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
                     String.format("Unable to access files in '%s'.", servicePath),
                     e);
             }
-        }));
+        }).collect(Collectors.toList());
+        return cache.getServiceBindings(serviceBindingRoots);
     }
 
     @Nullable

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
@@ -126,7 +126,7 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
     {
         this.rootPath = rootPath;
         this.parsingStrategies = parsingStrategies;
-        this.cache = Optional.ofNullable(cache).orElse(new FileSystemWatcherCache(this::parseServiceBinding));
+        this.cache = cache != null ? cache : new FileSystemWatcherCache(this::parseServiceBinding);
     }
 
     @Nonnull
@@ -151,7 +151,7 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
     @Nonnull
     private List<ServiceBinding> parseServiceBindings( @Nonnull final Stream<Path> servicePaths )
     {
-        final Stream<Path> bindingRoots = servicePaths.flatMap(servicePath -> {
+        return cache.getServiceBindings(servicePaths.flatMap(servicePath -> {
             try {
                 return Files.list(servicePath);
             }
@@ -160,9 +160,7 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
                     String.format("Unable to access files in '%s'.", servicePath),
                     e);
             }
-        });
-
-        return cache.getServiceBindings(bindingRoots.filter(Files::isDirectory));
+        }));
     }
 
     @Nullable

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
@@ -15,10 +15,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,6 +91,9 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
     @Nonnull
     private final Collection<LayeredParsingStrategy> parsingStrategies;
 
+    @Nonnull
+    private final DirectoryBasedCache cache;
+
     /**
      * Initializes a new {@link SapServiceOperatorLayeredServiceBindingAccessor} instance that uses the
      * {@link #DEFAULT_ROOT_PATH} and the {@link #DEFAULT_PARSING_STRATEGIES}.
@@ -103,7 +106,7 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
     /**
      * Initializes a new {@link SapServiceOperatorLayeredServiceBindingAccessor} that uses the given {@code rootPath}
      * and {@code parsingStrategies}.
-     * 
+     *
      * @param rootPath
      *            The service binding root {@link Path} that should be used.
      * @param parsingStrategies
@@ -113,8 +116,17 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
         @Nonnull final Path rootPath,
         @Nonnull final Collection<LayeredParsingStrategy> parsingStrategies )
     {
+        this(rootPath, parsingStrategies, null);
+    }
+
+    SapServiceOperatorLayeredServiceBindingAccessor(
+        @Nonnull final Path rootPath,
+        @Nonnull final Collection<LayeredParsingStrategy> parsingStrategies,
+        @Nullable final DirectoryBasedCache cache )
+    {
         this.rootPath = rootPath;
         this.parsingStrategies = parsingStrategies;
+        this.cache = Optional.ofNullable(cache).orElse(new FileSystemWatcherCache(this::parseServiceBinding));
     }
 
     @Nonnull
@@ -128,8 +140,8 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
             return Collections.emptyList();
         }
 
-        try( final Stream<Path> files = Files.list(rootPath) ) {
-            return files.filter(Files::isDirectory).flatMap(this::parseServiceBindings).collect(Collectors.toList());
+        try( final Stream<Path> servicePaths = Files.list(rootPath).filter(Files::isDirectory) ) {
+            return parseServiceBindings(servicePaths);
         }
         catch( final SecurityException | IOException e ) {
             throw new ServiceBindingAccessException("Unable to access service binding files.", e);
@@ -137,27 +149,33 @@ public class SapServiceOperatorLayeredServiceBindingAccessor implements ServiceB
     }
 
     @Nonnull
-    private Stream<ServiceBinding> parseServiceBindings( @Nonnull final Path servicePath )
+    private List<ServiceBinding> parseServiceBindings( @Nonnull final Stream<Path> servicePaths )
     {
-        try {
-            return Files
-                .list(servicePath)
-                .filter(Files::isDirectory)
-                .map(
-                    bindingPath -> parsingStrategies
-                        .stream()
-                        .map(strategy -> applyStrategy(strategy, servicePath, bindingPath))
-                        .filter(Optional::isPresent)
-                        .findFirst()
-                        .orElse(Optional.empty()))
-                .filter(Optional::isPresent)
-                .map(Optional::get);
-        }
-        catch( final IOException e ) {
-            throw new ServiceBindingAccessException(
-                String.format("Unable to access service binding files in '%s'.", servicePath),
-                e);
-        }
+        final Stream<Path> bindingRoots = servicePaths.flatMap(servicePath -> {
+            try {
+                return Files.list(servicePath);
+            }
+            catch( final IOException e ) {
+                throw new ServiceBindingAccessException(
+                    String.format("Unable to access files in '%s'.", servicePath),
+                    e);
+            }
+        });
+
+        return cache.getServiceBindings(bindingRoots.filter(Files::isDirectory));
+    }
+
+    @Nullable
+    private ServiceBinding parseServiceBinding( @Nonnull final Path bindingRoot )
+    {
+        final Path servicePath = bindingRoot.getParent();
+        return parsingStrategies
+            .stream()
+            .map(strategy -> applyStrategy(strategy, servicePath, bindingRoot))
+            .filter(Optional::isPresent)
+            .findFirst()
+            .orElse(Optional.empty())
+            .orElse(null);
     }
 
     @Nonnull

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -127,7 +126,7 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
     {
         this.environmentVariableReader = environmentVariableReader;
         this.charset = charset;
-        this.cache = Optional.ofNullable(cache).orElse(new FileSystemWatcherCache(this::parseServiceBinding));
+        this.cache = cache != null ? cache : new FileSystemWatcherCache(this::parseServiceBinding);
     }
 
     @Nonnull
@@ -141,8 +140,8 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
         }
 
         logger.debug("Reading service bindings from '{}'.", rootDirectory);
-        try( final Stream<Path> bindingRoots = Files.list(rootDirectory).filter(Files::isDirectory) ) {
-            return cache.getServiceBindings(bindingRoots);
+        try {
+            return cache.getServiceBindings(Files.list(rootDirectory));
         }
         catch( final IOException e ) {
             return Collections.emptyList();

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -140,8 +142,8 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
         }
 
         logger.debug("Reading service bindings from '{}'.", rootDirectory);
-        try {
-            return cache.getServiceBindings(Files.list(rootDirectory));
+        try( final Stream<Path> bindingRoots = Files.list(rootDirectory).filter(Files::isDirectory) ) {
+            return cache.getServiceBindings(bindingRoots.collect(Collectors.toList()));
         }
         catch( final IOException e ) {
             return Collections.emptyList();

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -93,6 +92,9 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
     @Nonnull
     private final Charset charset;
 
+    @Nonnull
+    private final DirectoryBasedCache cache;
+
     /**
      * Initializes a new {@link SapServiceOperatorServiceBindingIoAccessor} instance that uses the
      * {@link #DEFAULT_ENVIRONMENT_VARIABLE_READER} and the {@link #DEFAULT_CHARSET}.
@@ -115,8 +117,17 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
         @Nonnull final Function<String, String> environmentVariableReader,
         @Nonnull final Charset charset )
     {
+        this(environmentVariableReader, charset, null);
+    }
+
+    SapServiceOperatorServiceBindingIoAccessor(
+        @Nonnull final Function<String, String> environmentVariableReader,
+        @Nonnull final Charset charset,
+        @Nullable final DirectoryBasedCache cache )
+    {
         this.environmentVariableReader = environmentVariableReader;
         this.charset = charset;
+        this.cache = Optional.ofNullable(cache).orElse(new FileSystemWatcherCache(this::parseServiceBinding));
     }
 
     @Nonnull
@@ -131,11 +142,7 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
 
         logger.debug("Reading service bindings from '{}'.", rootDirectory);
         try( final Stream<Path> bindingRoots = Files.list(rootDirectory).filter(Files::isDirectory) ) {
-            return bindingRoots
-                .map(this::parseServiceBinding)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(Collectors.toList());
+            return cache.getServiceBindings(bindingRoots);
         }
         catch( final IOException e ) {
             return Collections.emptyList();
@@ -168,22 +175,22 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
         return rootDirectory;
     }
 
-    @Nonnull
-    private Optional<ServiceBinding> parseServiceBinding( @Nonnull final Path rootDirectory )
+    @Nullable
+    private ServiceBinding parseServiceBinding( @Nonnull final Path rootDirectory )
     {
         logger.debug("Trying to read service binding from '{}'.", rootDirectory);
         final Path metadataFile = rootDirectory.resolve(METADATA_FILE);
         if( !Files.exists(metadataFile) || !Files.isRegularFile(metadataFile) ) {
             // every service binding must contain a metadata file
             logger.debug("Skipping '{}': The directory does not contain a '{}' file.", rootDirectory, METADATA_FILE);
-            return Optional.empty();
+            return null;
         }
 
         final Optional<BindingMetadata> maybeBindingMetadata = BindingMetadataFactory.tryFromJsonFile(metadataFile);
         if( !maybeBindingMetadata.isPresent() ) {
             // metadata file cannot be parsed
             logger.debug("Skipping '{}': Unable to parse the '{}' file.", rootDirectory, METADATA_FILE);
-            return Optional.empty();
+            return null;
         }
 
         final String bindingName = rootDirectory.getFileName().toString();
@@ -199,7 +206,7 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
         if( !maybeServiceName.isPresent() ) {
             // the service name property is mandatory
             logger.debug("Skipping '{}': No '{}' property found.", rootDirectory, SERVICE_NAME_KEY);
-            return Optional.empty();
+            return null;
         }
 
         final Map<String, Object> rawCredentials = new HashMap<>();
@@ -209,7 +216,7 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
         if( rawCredentials.isEmpty() ) {
             // bindings must always have credentials
             logger.debug("Skipping '{}': No credentials property found.", rootDirectory);
-            return Optional.empty();
+            return null;
         }
 
         final String credentialsKey = generateNewKey(rawServiceBinding);
@@ -226,7 +233,7 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
                 .withCredentialsKey(credentialsKey)
                 .build();
         logger.debug("Successfully read service binding from '{}'.", rootDirectory);
-        return Optional.of(serviceBinding);
+        return serviceBinding;
     }
 
     private void addProperty(

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -15,13 +15,13 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -74,6 +74,7 @@ class FileSystemWatcherCacheTest
     }
 
     @Test
+    @Disabled( "This test doesn't work properly when executed via GH actions." )
     void loadWillHitFileSystemWhenFileIsCreated( @Nonnull @TempDir final Path rootDirectory )
     {
         final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
@@ -96,6 +97,7 @@ class FileSystemWatcherCacheTest
     }
 
     @Test
+    @Disabled( "This test doesn't work properly when executed via GH actions." )
     void loadWillHitFileSystemWhenFileIsModified( @Nonnull @TempDir final Path rootDirectory )
     {
         final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
@@ -118,6 +120,7 @@ class FileSystemWatcherCacheTest
     }
 
     @Test
+    @Disabled( "This test doesn't work properly when executed via GH actions." )
     void loadWillHitFileSystemWhenFileIsDeleted( @Nonnull @TempDir final Path rootDirectory )
         throws IOException
     {
@@ -205,27 +208,10 @@ class FileSystemWatcherCacheTest
             }
 
             Files.write(filePath, Collections.singletonList(content), StandardCharsets.UTF_8);
-
-            // make sure the changes are actually reflected in the file system
-            boolean changesAreApplied = false;
-            for( int i = 0; i < 10; ++i ) {
-                final String actualContent = String.join("\n", Files.readAllLines(filePath, StandardCharsets.UTF_8));
-                if( actualContent.equals(content) ) {
-                    changesAreApplied = true;
-                    break;
-                }
-
-                Thread.sleep(100);
-            }
-
-            assertThat(changesAreApplied)
-                .withFailMessage("Changes to the file '%s' have not been applied.", filePath)
-                .isTrue();
             return filePath;
         }
-        catch( final IOException | InterruptedException e ) {
-            fail("Failed to write test file content.", e);
-            throw new AssertionError("Should not be reached.");
+        catch( final IOException e ) {
+            throw new AssertionError(String.format("Failed to write content to test file '%s'.", filePath), e);
         }
     }
 

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -205,9 +205,25 @@ class FileSystemWatcherCacheTest
             }
 
             Files.write(filePath, Collections.singletonList(content), StandardCharsets.UTF_8);
+
+            // make sure the changes are actually reflected in the file system
+            boolean changesAreApplied = false;
+            for( int i = 0; i < 10; ++i ) {
+                final String actualContent = String.join("\n", Files.readAllLines(filePath, StandardCharsets.UTF_8));
+                if( actualContent.equals(content) ) {
+                    changesAreApplied = true;
+                    break;
+                }
+
+                Thread.sleep(100);
+            }
+
+            assertThat(changesAreApplied)
+                .withFailMessage("Changes to the file '%s' have not been applied.", filePath)
+                .isTrue();
             return filePath;
         }
-        catch( final IOException e ) {
+        catch( final IOException | InterruptedException e ) {
             fail("Failed to write test file content.", e);
             throw new AssertionError("Should not be reached.");
         }

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -81,19 +81,32 @@ class FileSystemWatcherCacheTest
         // manually create cache entries
         sut.cachedServiceBindings.put(dir, mock(ServiceBinding.class));
 
-        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
-        when(mockedWatchEvent.kind()).thenReturn(ENTRY_CREATE);
-
         final WatchKey mockedWatchKey = mock(WatchKey.class);
         when(mockedWatchKey.isValid()).thenReturn(true);
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
+        // file system has not been changed
+        when(mockedWatchKey.pollEvents()).thenReturn(Collections.emptyList());
 
         sut.directoryWatchKeys.put(dir, mockedWatchKey);
 
         final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
 
         assertThat(firstBindings.size()).isEqualTo(1);
+        // service binding is not reloaded
+        verify(mockedLoader, times(0)).apply(eq(dir));
+        verify(mockedWatchKey, times(1)).pollEvents();
+
+        // mark the file system as changed
+        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
+        when(mockedWatchEvent.kind()).thenReturn(ENTRY_CREATE);
+        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
+
+        // load again
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(secondBindings.size()).isEqualTo(1);
+        // service binding is reloaded
         verify(mockedLoader, times(1)).apply(eq(dir));
+        verify(mockedWatchKey, times(2)).pollEvents();
     }
 
     @Test
@@ -109,19 +122,32 @@ class FileSystemWatcherCacheTest
         // manually create cache entries
         sut.cachedServiceBindings.put(dir, mock(ServiceBinding.class));
 
-        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
-        when(mockedWatchEvent.kind()).thenReturn(ENTRY_MODIFY);
-
         final WatchKey mockedWatchKey = mock(WatchKey.class);
         when(mockedWatchKey.isValid()).thenReturn(true);
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
+        // file system has not been changed
+        when(mockedWatchKey.pollEvents()).thenReturn(Collections.emptyList());
 
         sut.directoryWatchKeys.put(dir, mockedWatchKey);
 
         final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
 
         assertThat(firstBindings.size()).isEqualTo(1);
+        // service binding is not reloaded
+        verify(mockedLoader, times(0)).apply(eq(dir));
+        verify(mockedWatchKey, times(1)).pollEvents();
+
+        // mark the file system as changed
+        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
+        when(mockedWatchEvent.kind()).thenReturn(ENTRY_MODIFY);
+        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
+
+        // load again
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(secondBindings.size()).isEqualTo(1);
+        // service binding is reloaded
         verify(mockedLoader, times(1)).apply(eq(dir));
+        verify(mockedWatchKey, times(2)).pollEvents();
     }
 
     @Test
@@ -137,19 +163,32 @@ class FileSystemWatcherCacheTest
         // manually create cache entries
         sut.cachedServiceBindings.put(dir, mock(ServiceBinding.class));
 
-        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
-        when(mockedWatchEvent.kind()).thenReturn(ENTRY_DELETE);
-
         final WatchKey mockedWatchKey = mock(WatchKey.class);
         when(mockedWatchKey.isValid()).thenReturn(true);
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
+        // file system has not been changed
+        when(mockedWatchKey.pollEvents()).thenReturn(Collections.emptyList());
 
         sut.directoryWatchKeys.put(dir, mockedWatchKey);
 
         final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
 
         assertThat(firstBindings.size()).isEqualTo(1);
+        // service binding is not reloaded
+        verify(mockedLoader, times(0)).apply(eq(dir));
+        verify(mockedWatchKey, times(1)).pollEvents();
+
+        // mark the file system as changed
+        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
+        when(mockedWatchEvent.kind()).thenReturn(ENTRY_DELETE);
+        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
+
+        // load again
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(secondBindings.size()).isEqualTo(1);
+        // service binding is reloaded
         verify(mockedLoader, times(1)).apply(eq(dir));
+        verify(mockedWatchKey, times(2)).pollEvents();
     }
 
     @Test

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -9,9 +9,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -248,10 +250,10 @@ class FileSystemWatcherCacheTest
     }
 
     @Nonnull
-    private static Stream<Path> getAllDirectories( @Nonnull final Path rootDirectory )
+    private static Collection<Path> getAllDirectories( @Nonnull final Path rootDirectory )
     {
-        try {
-            return Files.list(rootDirectory);
+        try( final Stream<Path> dirs = Files.list(rootDirectory).filter(Files::isDirectory) ) {
+            return dirs.collect(Collectors.toList());
         }
         catch( final IOException e ) {
             throw new AssertionError(String.format("Unable to get all directories in '%s'.", rootDirectory), e);

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -196,22 +196,27 @@ class FileSystemWatcherCacheTest
         throws IOException
     {
         final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
-        final Path dir = Files.createDirectories(rootDirectory.resolve("dir"));
+        final Path dir1 = Files.createDirectories(rootDirectory.resolve("dir1"));
+        final Path dir2 = Files.createDirectories(rootDirectory.resolve("dir2"));
 
         final FileSystemWatcherCache sut = new FileSystemWatcherCache(mockedLoader);
 
         // manually create cache entries
-        sut.cachedServiceBindings.put(dir, mock(ServiceBinding.class));
+        sut.cachedServiceBindings.put(dir1, mock(ServiceBinding.class));
+        sut.cachedServiceBindings.put(dir2, mock(ServiceBinding.class));
 
-        final WatchKey mockedWatchKey = mock(WatchKey.class);
-        sut.directoryWatchKeys.put(dir, mockedWatchKey);
+        final WatchKey mockedWatchKey1 = mock(WatchKey.class);
+        final WatchKey mockedWatchKey2 = mock(WatchKey.class);
+        sut.directoryWatchKeys.put(dir1, mockedWatchKey1);
+        sut.directoryWatchKeys.put(dir2, mockedWatchKey2);
 
         sut.getServiceBindings(Collections.emptyList());
 
         assertThat(sut.directoryWatchKeys).isEmpty();
         assertThat(sut.cachedServiceBindings).isEmpty();
 
-        verify(mockedWatchKey, times(1)).cancel();
+        verify(mockedWatchKey1, times(1)).cancel();
+        verify(mockedWatchKey2, times(1)).cancel();
     }
 
     @Test

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved.
+ */
+
+package com.sap.cloud.environment.servicebinding;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FileSystemWatcherCacheTest
+{
+    private Function<Path, ServiceBinding> mockedLoader;
+
+    @BeforeEach
+    @SuppressWarnings( "unchecked" )
+    void setupMockedLoader()
+    {
+        mockedLoader = (Function<Path, ServiceBinding>) mock(Function.class);
+        when(mockedLoader.apply(any())).thenReturn(mock(ServiceBinding.class));
+    }
+
+    @Test
+    void initialLoadWillHitTheFileSystem( @Nonnull @TempDir final Path rootDirectory )
+    {
+        final Path dir1 = rootDirectory.resolve("dir1");
+        final Path dir2 = rootDirectory.resolve("dir2");
+        write(dir1.resolve("file1"), "foo");
+        write(dir2.resolve("file2"), "bar");
+
+        final DirectoryBasedCache sut = new FileSystemWatcherCache(mockedLoader);
+        final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(bindings.size()).isEqualTo(2);
+        verify(mockedLoader, times(1)).apply(eq(dir1));
+        verify(mockedLoader, times(1)).apply(eq(dir2));
+    }
+
+    @Test
+    void subsequentLoadWillHitTheCache( @Nonnull @TempDir final Path rootDirectory )
+    {
+        final Path dir1 = rootDirectory.resolve("dir1");
+        final Path dir2 = rootDirectory.resolve("dir2");
+        write(dir1.resolve("file1"), "foo");
+        write(dir2.resolve("file2"), "bar");
+
+        final DirectoryBasedCache sut = new FileSystemWatcherCache(mockedLoader);
+        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(firstBindings.size()).isEqualTo(2);
+        verify(mockedLoader, times(1)).apply(eq(dir1));
+        verify(mockedLoader, times(1)).apply(eq(dir2));
+
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(secondBindings.size()).isEqualTo(2);
+        verify(mockedLoader, times(1)).apply(eq(dir1));
+        verify(mockedLoader, times(1)).apply(eq(dir2));
+    }
+
+    @Test
+    void loadWillHitFileSystemWhenFileIsCreated( @Nonnull @TempDir final Path rootDirectory )
+    {
+        final Path dir = rootDirectory.resolve("dir1");
+        write(dir.resolve("file1"), "foo");
+
+        final DirectoryBasedCache sut = new FileSystemWatcherCache(mockedLoader);
+        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(firstBindings.size()).isEqualTo(1);
+        verify(mockedLoader, times(1)).apply(eq(dir));
+
+        // create a new file
+        write(dir.resolve("file2"), "bar");
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(secondBindings.size()).isEqualTo(1);
+        verify(mockedLoader, times(2)).apply(eq(dir));
+    }
+
+    @Test
+    void loadWillHitFileSystemWhenFileIsModified( @Nonnull @TempDir final Path rootDirectory )
+    {
+        final Path dir = rootDirectory.resolve("dir1");
+        final Path file = write(dir.resolve("file1"), "foo");
+
+        final DirectoryBasedCache sut = new FileSystemWatcherCache(mockedLoader);
+        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(firstBindings.size()).isEqualTo(1);
+        verify(mockedLoader, times(1)).apply(eq(dir));
+
+        // modify existing file
+        write(file, "bar");
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(secondBindings.size()).isEqualTo(1);
+        verify(mockedLoader, times(2)).apply(eq(dir));
+    }
+
+    @Test
+    void loadWillHitFileSystemWhenFileIsDeleted( @Nonnull @TempDir final Path rootDirectory )
+        throws IOException
+    {
+        final Path dir = rootDirectory.resolve("dir1");
+        final Path file = write(dir.resolve("file1"), "foo");
+
+        final DirectoryBasedCache sut = new FileSystemWatcherCache(mockedLoader);
+        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(firstBindings.size()).isEqualTo(1);
+        verify(mockedLoader, times(1)).apply(eq(dir));
+
+        // delete existing file
+        Files.delete(file);
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(secondBindings.size()).isEqualTo(1);
+        verify(mockedLoader, times(2)).apply(eq(dir));
+    }
+
+    @Test
+    void loadWillRemoveCacheEntry( @Nonnull @TempDir final Path rootDirectory )
+    {
+        final Path dir = rootDirectory.resolve("dir1");
+        write(dir.resolve("file1"), "foo");
+
+        final DirectoryBasedCache sut = new FileSystemWatcherCache(mockedLoader);
+        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(firstBindings.size()).isEqualTo(1);
+        verify(mockedLoader, times(1)).apply(eq(dir));
+
+        // load without the existing directory will remove the cache entry
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(Collections.emptyList());
+
+        assertThat(secondBindings.size()).isEqualTo(0);
+        verify(mockedLoader, times(1)).apply(eq(dir));
+
+        // load with the existing directory will hit the file system,
+        // even though the file system has not been changed in the meanwhile
+        final List<ServiceBinding> thirdBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(thirdBindings.size()).isEqualTo(1);
+        verify(mockedLoader, times(2)).apply(eq(dir));
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void loadWillIgnoreBindingWhenLoaderReturnsNull( @Nonnull @TempDir final Path rootDirectory )
+        throws IOException
+    {
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        when(loader.apply(any())).thenReturn(null);
+
+        final Path dir = Files.createDirectories(rootDirectory.resolve("dir"));
+
+        final DirectoryBasedCache sut = new FileSystemWatcherCache(loader);
+
+        final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
+
+        assertThat(bindings.size()).isEqualTo(0);
+        verify(loader, times(1)).apply(eq(dir));
+    }
+
+    @Nonnull
+    private static Path write( @Nonnull final Path filePath, @Nonnull final String content )
+    {
+        try {
+            if( !Files.exists(filePath.getParent()) ) {
+                Files.createDirectories(filePath.getParent());
+            }
+
+            Files.write(filePath, Collections.singletonList(content), StandardCharsets.UTF_8);
+            return filePath;
+        }
+        catch( final IOException e ) {
+            fail("Failed to write test file content.", e);
+            throw new AssertionError("Should not be reached.");
+        }
+    }
+
+    @Nonnull
+    @SuppressWarnings( "resource" )
+    private static Stream<Path> getAllDirectories( @Nonnull final Path rootDirectory )
+    {
+        try {
+            return Files.list(rootDirectory).filter(Files::isDirectory);
+        }
+        catch( final IOException e ) {
+            throw new AssertionError(String.format("Unable to get all directories in '%s'.", rootDirectory), e);
+        }
+    }
+}

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -243,11 +243,10 @@ class FileSystemWatcherCacheTest
     }
 
     @Nonnull
-    @SuppressWarnings( "resource" )
     private static Stream<Path> getAllDirectories( @Nonnull final Path rootDirectory )
     {
         try {
-            return Files.list(rootDirectory).filter(Files::isDirectory);
+            return Files.list(rootDirectory);
         }
         catch( final IOException e ) {
             throw new AssertionError(String.format("Unable to get all directories in '%s'.", rootDirectory), e);

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -15,7 +15,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -32,19 +31,11 @@ import static org.mockito.Mockito.when;
 
 class FileSystemWatcherCacheTest
 {
-    private Function<Path, ServiceBinding> mockedLoader;
-
-    @BeforeEach
-    @SuppressWarnings( "unchecked" )
-    void setupMockedLoader()
-    {
-        mockedLoader = (Function<Path, ServiceBinding>) mock(Function.class);
-        when(mockedLoader.apply(any())).thenReturn(mock(ServiceBinding.class));
-    }
-
     @Test
     void initialLoadWillHitTheFileSystem( @Nonnull @TempDir final Path rootDirectory )
     {
+        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
+
         final Path dir1 = rootDirectory.resolve("dir1");
         final Path dir2 = rootDirectory.resolve("dir2");
         write(dir1.resolve("file1"), "foo");
@@ -61,6 +52,8 @@ class FileSystemWatcherCacheTest
     @Test
     void subsequentLoadWillHitTheCache( @Nonnull @TempDir final Path rootDirectory )
     {
+        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
+
         final Path dir1 = rootDirectory.resolve("dir1");
         final Path dir2 = rootDirectory.resolve("dir2");
         write(dir1.resolve("file1"), "foo");
@@ -83,6 +76,8 @@ class FileSystemWatcherCacheTest
     @Test
     void loadWillHitFileSystemWhenFileIsCreated( @Nonnull @TempDir final Path rootDirectory )
     {
+        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
+
         final Path dir = rootDirectory.resolve("dir1");
         write(dir.resolve("file1"), "foo");
 
@@ -103,6 +98,8 @@ class FileSystemWatcherCacheTest
     @Test
     void loadWillHitFileSystemWhenFileIsModified( @Nonnull @TempDir final Path rootDirectory )
     {
+        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
+
         final Path dir = rootDirectory.resolve("dir1");
         final Path file = write(dir.resolve("file1"), "foo");
 
@@ -124,6 +121,8 @@ class FileSystemWatcherCacheTest
     void loadWillHitFileSystemWhenFileIsDeleted( @Nonnull @TempDir final Path rootDirectory )
         throws IOException
     {
+        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
+
         final Path dir = rootDirectory.resolve("dir1");
         final Path file = write(dir.resolve("file1"), "foo");
 
@@ -144,6 +143,8 @@ class FileSystemWatcherCacheTest
     @Test
     void loadWillRemoveCacheEntry( @Nonnull @TempDir final Path rootDirectory )
     {
+        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
+
         final Path dir = rootDirectory.resolve("dir1");
         write(dir.resolve("file1"), "foo");
 
@@ -183,6 +184,16 @@ class FileSystemWatcherCacheTest
 
         assertThat(bindings.size()).isEqualTo(0);
         verify(loader, times(1)).apply(eq(dir));
+    }
+
+    @Nonnull
+    @SuppressWarnings( "unchecked" )
+    private static Function<Path, ServiceBinding> mockedServiceBindingLoader()
+    {
+        final Function<Path, ServiceBinding> mock = (Function<Path, ServiceBinding>) mock(Function.class);
+        when(mock.apply(any())).thenReturn(mock(ServiceBinding.class));
+
+        return mock;
     }
 
     @Nonnull

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessorTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessorTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
@@ -106,7 +105,6 @@ class SapServiceOperatorLayeredServiceBindingAccessorTest
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void serviceBindingsAreServedFromCache( @Nonnull @TempDir final Path rootDirectory )
         throws IOException
     {
@@ -114,16 +112,16 @@ class SapServiceOperatorLayeredServiceBindingAccessorTest
 
         final List<ServiceBinding> serviceBindings = Collections.singletonList(mock(ServiceBinding.class));
         final DirectoryBasedCache mockedCache = mock(DirectoryBasedCache.class);
-        when(mockedCache.getServiceBindings((Stream<Path>) any())).thenReturn(serviceBindings);
+        when(mockedCache.getServiceBindings(any())).thenReturn(serviceBindings);
 
         final ServiceBindingAccessor sut =
             new SapServiceOperatorLayeredServiceBindingAccessor(rootDirectory, DEFAULT_PARSING_STRATEGIES, mockedCache);
 
         assertThat(sut.getServiceBindings()).isSameAs(serviceBindings);
-        verify(mockedCache, times(1)).getServiceBindings((Stream<Path>) any());
+        verify(mockedCache, times(1)).getServiceBindings(any());
 
         assertThat(sut.getServiceBindings()).isSameAs(serviceBindings);
-        verify(mockedCache, times(2)).getServiceBindings((Stream<Path>) any());
+        verify(mockedCache, times(2)).getServiceBindings(any());
     }
 
     private static void assertContainsSecretKeyBinding( @Nonnull final List<ServiceBinding> serviceBindings )

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessorTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessorTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
@@ -408,7 +407,7 @@ class SapServiceOperatorServiceBindingIoAccessorTest
 
         final List<ServiceBinding> serviceBindings = Collections.singletonList(mock(ServiceBinding.class));
         final DirectoryBasedCache mockedCache = mock(DirectoryBasedCache.class);
-        when(mockedCache.getServiceBindings((Stream<Path>) any())).thenReturn(serviceBindings);
+        when(mockedCache.getServiceBindings(any())).thenReturn(serviceBindings);
 
         final Function<String, String> reader = mock(Function.class);
         when(reader.apply(eq("SERVICE_BINDING_ROOT"))).thenReturn(rootDirectory.toString());
@@ -421,10 +420,10 @@ class SapServiceOperatorServiceBindingIoAccessorTest
                 mockedCache);
 
         assertThat(sut.getServiceBindings()).isSameAs(serviceBindings);
-        verify(mockedCache, times(1)).getServiceBindings((Stream<Path>) any());
+        verify(mockedCache, times(1)).getServiceBindings(any());
 
         assertThat(sut.getServiceBindings()).isSameAs(serviceBindings);
-        verify(mockedCache, times(2)).getServiceBindings((Stream<Path>) any());
+        verify(mockedCache, times(2)).getServiceBindings(any());
     }
 
     private static void assertContainsDataXsuaaBinding( @Nonnull final List<ServiceBinding> serviceBindings )


### PR DESCRIPTION
## Context

This PR introduces a new **internal** `DirectoryBasedCache`, which is used by the `SapServiceOperatorLayeredServiceBindingAccessor` and the `SapServiceOperatorServiceBindingIoAccessor` to reload `ServiceBinding`s only in case the underlying filesystem was changed (i.e. when reloading is expected to have a different result).

### Feature Scope

- [x] Implement, test, and use the new `DirectoryBasedCache`

<details>
<summary><h3>Release Notes</h3></summary>

<h3>Module: <code>java-sap-service-operator</code></h3>

<ul>
<li>Both <code>ServiceBindingAccessor</code> implementations make use of a new filesystem-aware cache, which will limit the amount of filesystem accesses to the necessary minimum.</li>
</ul>

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] Feature scope is tested
- [x] ~Feature scope is documented~ (No documentation needed as the new caching API is internal)
- [x] Release notes are created
