### PR TITLE
Feat: Add `KEEP_UNIQUE` Default `EqualityComparer` Implementation

### DIFF
--- a/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMerger.java
+++ b/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMerger.java
@@ -38,6 +38,14 @@ public class ServiceBindingMerger implements ServiceBindingAccessor
     @Nonnull
     public static final EqualityComparer KEEP_EVERYTHING = ( a, b ) -> false;
 
+    /**
+     * A {@link EqualityComparer} that compares {@link ServiceBinding} instance by using the
+     * {@link Object#equals(Object)} implementation. Therefore, duplicated (i.e. non-unique) {@link ServiceBinding}s
+     * will <b>not</b> be included in the combined result set.
+     */
+    @Nonnull
+    public static final EqualityComparer KEEP_UNIQUE = Object::equals;
+
     @Nonnull
     private final Collection<ServiceBindingAccessor> accessors;
 

--- a/api-parent/access-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMergerTest.java
+++ b/api-parent/access-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMergerTest.java
@@ -4,17 +4,22 @@
 
 package com.sap.cloud.environment.servicebinding.api;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
+import static com.sap.cloud.environment.servicebinding.api.ServiceBindingMerger.KEEP_UNIQUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -99,6 +104,40 @@ class ServiceBindingMergerTest
         assertThat(ServiceBindingMerger.KEEP_EVERYTHING.areEqual(binding, binding)).isFalse();
     }
 
+    @Test
+    void keepUniqueDoesNotIncludeDuplicates()
+    {
+        final ComparableServiceBinding bindingA = new ComparableServiceBinding();
+        final ComparableServiceBinding bindingB = new ComparableServiceBinding();
+        final ComparableServiceBinding bindingC = new ComparableServiceBinding();
+
+        // bindings A and C are equal
+        bindingA.getEqualBindings().add(bindingC);
+        bindingC.getEqualBindings().add(bindingA);
+
+        final ServiceBindingAccessor accessorA = () -> Arrays.asList(bindingA, bindingB);
+        final ServiceBindingAccessor accessorB = () -> Arrays.asList(bindingB, bindingC);
+
+        final ServiceBindingMerger sut = new ServiceBindingMerger(Arrays.asList(accessorA, accessorB), KEEP_UNIQUE);
+
+        assertThat(sut.getServiceBindings()).containsExactlyInAnyOrder(bindingA, bindingB);
+    }
+
+    @Test
+    void keepUniqueUsesEquals()
+    {
+        final ComparableServiceBinding a = new ComparableServiceBinding();
+        final ComparableServiceBinding b = new ComparableServiceBinding();
+
+        assertThat(KEEP_UNIQUE.areEqual(a, a)).isTrue();
+        assertThat(KEEP_UNIQUE.areEqual(a, b)).isFalse();
+
+        // the order of these assertions is important, since the `containsExactly` assertion will also use the `equals` method.
+        // therefore, if we were to check for `a` first, `b#equals` would also be invoked
+        assertThat(b.getEqualsInvocations()).isEmpty();
+        assertThat(a.getEqualsInvocations()).containsExactly(a, b);
+    }
+
     @Nonnull
     private static ServiceBinding serviceBinding( @Nonnull final String serviceType, @Nonnull final String plan )
     {
@@ -130,5 +169,90 @@ class ServiceBindingMergerTest
             return a.getServiceName().equals(b.getServiceName()) && a.getServicePlan().equals(b.getServicePlan());
         }
 
+    }
+
+    private static class ComparableServiceBinding implements ServiceBinding
+    {
+        private final List<ServiceBinding> equalBindings = new ArrayList<>();
+        private final List<Object> equalsInvocations = new ArrayList<>();
+
+        @Nonnull
+        public List<ServiceBinding> getEqualBindings()
+        {
+            return equalBindings;
+        }
+
+        @Nonnull
+        public List<Object> getEqualsInvocations()
+        {
+            return equalsInvocations;
+        }
+
+        @Nonnull
+        @Override
+        public Set<String> getKeys()
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean containsKey( @Nonnull String key )
+        {
+            return false;
+        }
+
+        @Nonnull
+        @Override
+        public Optional<Object> get( @Nonnull String key )
+        {
+            return Optional.empty();
+        }
+
+        @Nonnull
+        @Override
+        public Optional<String> getName()
+        {
+            return Optional.empty();
+        }
+
+        @Nonnull
+        @Override
+        public Optional<String> getServiceName()
+        {
+            return Optional.empty();
+        }
+
+        @Nonnull
+        @Override
+        public Optional<String> getServicePlan()
+        {
+            return Optional.empty();
+        }
+
+        @Nonnull
+        @Override
+        public List<String> getTags()
+        {
+            return Collections.emptyList();
+        }
+
+        @Nonnull
+        @Override
+        public Map<String, Object> getCredentials()
+        {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public boolean equals( @Nullable final Object obj )
+        {
+            equalsInvocations.add(obj);
+
+            if( this == obj ) {
+                return true;
+            }
+
+            return equalBindings.stream().anyMatch(binding -> binding == obj);
+        }
     }
 }

--- a/api-parent/access-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMergerTest.java
+++ b/api-parent/access-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMergerTest.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
+import static com.sap.cloud.environment.servicebinding.api.ServiceBindingMerger.KEEP_EVERYTHING;
 import static com.sap.cloud.environment.servicebinding.api.ServiceBindingMerger.KEEP_UNIQUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -101,7 +102,7 @@ class ServiceBindingMergerTest
     {
         final ServiceBinding binding = serviceBinding("XSUAA", "lite");
 
-        assertThat(ServiceBindingMerger.KEEP_EVERYTHING.areEqual(binding, binding)).isFalse();
+        assertThat(KEEP_EVERYTHING.areEqual(binding, binding)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Context

This PR introduces a new default implementation of the `ServiceBindingMerger.EqualityComparer` interface: The `KEEP_UNIQUE` comparer.
This new comparer will use the `#equals` method of the provided `ServiceBinding` to check whether the first parameter is equal to the second one.

**Caution**: The check is performed only one-directional, i.e. the implementation is just checking whether `a.equals(b)` **but not** whether `b.equals(a)`.

### Feature Scope

- [x] Add new default implementation for convenience to the `ServiceBindingMerger`

<details>
<summary><h3>Release Notes</h3></summary>

<h3>Module: <code>java-access-api</code></h3>

<ul>
<li>Add the <code>KEEP_UNIQUE</code> <code>ServiceBindingMerger.EqualityComparer</code> for convenience to the <code>ServiceBindingMerger</code>. This implementation will use <code>equals</code> to determine the equality of the given <code>ServiceBinding</code> instances.</li>
</ul>

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] Feature scope is tested
- [x] Feature scope is documented (documented via JavaDoc)
- [x] Release notes are created
