### PR TITLE
Feat: Convenience for (partial) Customization

### DIFF
--- a/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingAccessor.java
+++ b/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingAccessor.java
@@ -4,10 +4,8 @@
 
 package com.sap.cloud.environment.servicebinding.api;
 
-import java.util.Collection;
-import java.util.ServiceLoader;
+import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -23,11 +21,11 @@ import org.slf4j.LoggerFactory;
  * <bold>Please note:</bold> It is considered best practice to offer APIs that accept a dedicated
  * {@link ServiceBindingAccessor} instance instead of using the globally available instance stored inside this class.
  * For example, libraries that are using {@link ServiceBindingAccessor}s should offer APIs such as the following:
- * 
+ *
  * <pre>
  * public ReturnType doSomethingWithServiceBindings( @Nonnull final ServiceBindingAccessor accessor );
  * </pre>
- * 
+ * <p>
  * If that is, for some reason, not feasible, only then should this static default instance be used.
  */
 public final class DefaultServiceBindingAccessor
@@ -48,7 +46,8 @@ public final class DefaultServiceBindingAccessor
      * by using {@link DefaultServiceBindingAccessor#setInstance(ServiceBindingAccessor)}. <br>
      * By default, the returned {@link ServiceBindingAccessor} will be assembled in the following way:
      * <ol>
-     * <li>Use the {@link ServiceLoader} to find implementations of {@link ServiceBindingAccessor}.</li>
+     * <li>Use {@link ServiceBindingAccessor#getInstancesViaServiceLoader()} to retrieve a list of
+     * {@link ServiceBindingAccessor} instances.</li>
      * <li>Combine instances of the found implementations using the {@link ServiceBindingMerger} (the merging strategy
      * used is {@link ServiceBindingMerger#KEEP_EVERYTHING}).</li>
      * <li>Wrap the resulting instance of {@link ServiceBindingMerger} into a {@link SimpleServiceBindingCache}.</li>
@@ -84,24 +83,21 @@ public final class DefaultServiceBindingAccessor
     @Nonnull
     private static ServiceBindingAccessor newDefaultInstance()
     {
-        final ClassLoader classLoader = DefaultServiceBindingAccessor.class.getClassLoader();
-        final ServiceLoader<ServiceBindingAccessor> serviceLoader =
-            ServiceLoader.load(ServiceBindingAccessor.class, classLoader);
-        final Collection<ServiceBindingAccessor> accessors =
-            StreamSupport.stream(serviceLoader.spliterator(), false).collect(Collectors.toList());
+        final List<ServiceBindingAccessor> defaultAccessors = ServiceBindingAccessor.getInstancesViaServiceLoader();
 
         if( logger.isDebugEnabled() ) {
             final String classNames =
-                accessors.stream().map(Object::getClass).map(Class::getName).collect(Collectors.joining(", "));
+                defaultAccessors.stream().map(Object::getClass).map(Class::getName).collect(Collectors.joining(", "));
             logger
                 .debug(
-                    "Following implementations of {} were found: {}.",
+                    "Following implementations of {} will be used for the {}: {}.",
                     ServiceBindingAccessor.class.getSimpleName(),
+                    DefaultServiceBindingAccessor.class.getSimpleName(),
                     classNames);
         }
 
         final ServiceBindingMerger bindingMerger =
-            new ServiceBindingMerger(accessors, ServiceBindingMerger.KEEP_EVERYTHING);
+            new ServiceBindingMerger(defaultAccessors, ServiceBindingMerger.KEEP_EVERYTHING);
 
         return new SimpleServiceBindingCache(bindingMerger);
     }

--- a/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingAccessor.java
+++ b/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingAccessor.java
@@ -5,6 +5,9 @@
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nonnull;
 
@@ -16,6 +19,37 @@ import com.sap.cloud.environment.servicebinding.api.exception.ServiceBindingAcce
 @FunctionalInterface
 public interface ServiceBindingAccessor
 {
+    /**
+     * Returns {@link ServiceBindingAccessor} instances for implementations that are exposed via the
+     * <a href="https://xperti.io/blogs/understanding-java-service-loader/">Service Loader Pattern</a>.
+     * <p>
+     * </p>
+     * These instances are useful when the behavior of one (or more) specific {@link ServiceBindingAccessor}s should be
+     * overwritten while leaving others in their default state. <br>
+     * <b>Example:</b>
+     * 
+     * <pre>
+     * final List<ServiceBindingAccessor> defaultInstances = ServiceBindingAccessor.getInstancesViaServiceLoader();
+     * if( defaultInstances.removeIf(SapVcapServicesServiceBindingAccessor.class::isInstance) ) {
+     *     defaultInstances.add(new SapVcapServicesServiceBindingAccessor(customEnvironmentVariableReader));
+     * }
+     *
+     * final ServiceBindingMerger merger = new ServiceBindingMerger(defaultInstances, ServiceBindingMerger.KEEP_UNIQUE);
+     * final SimpleServiceBindingCache cache = new SimpleServiceBindingCache(merger);
+     *
+     * DefaultServiceBindingAccessor.setInstance(cache);
+     * </pre>
+     *
+     * @return A {@link List} of {@link ServiceBindingAccessor} instances created from implementations that are exposed
+     *         via the <i>Service Locator Pattern</i> (see above).
+     */
+    static List<ServiceBindingAccessor> getInstancesViaServiceLoader()
+    {
+        final ServiceLoader<ServiceBindingAccessor> serviceLoader =
+            ServiceLoader.load(ServiceBindingAccessor.class, ServiceBindingAccessor.class.getClassLoader());
+        return StreamSupport.stream(serviceLoader.spliterator(), false).collect(Collectors.toList());
+    }
+
     /**
      * Retrieves all {@link ServiceBinding}s that are accessible for this {@link ServiceBindingAccessor}.
      *


### PR DESCRIPTION
## Context

This PR introduces a new convenience method (`ServiceBindingAccessor#getInstancesViaServiceLoader`) which returns a `List<ServiceBindingAccessor>` created via the [Service Loader Pattern](https://xperti.io/blogs/understanding-java-service-loader).
This method is especially useful when individual default `ServiceBindingAccessor`s should be replaced/removed from the default loading behavior.

The following code demonstrates a potential usage scenario:
```java
final List<ServiceBindingAccessor> defaultInstances = ServiceBindingAccessor.getInstancesViaServiceLoader();
if( defaultInstances.removeIf(SapVcapServicesServiceBindingAccessor.class::isInstance) ) {
    defaultInstances.add(new SapVcapServicesServiceBindingAccessor(customEnvironmentVariableReader));
}

final ServiceBindingMerger merger = new ServiceBindingMerger(defaultInstances, ServiceBindingMerger.KEEP_UNIQUE);
final SimpleServiceBindingCache cache = new SimpleServiceBindingCache(merger);

DefaultServiceBindingAccessor.setInstance(cache);
```

### Feature Scope

- [x] Convenience method is implemented

<details>
<summary><h3>Release Notes</h3></summary>

<h3>Module: <code>java-access-api</code></h3>

<ul>
<li>Add <code>#getInstancesViaServiceLoader</code> to the <code>ServiceBindingAccessor</code> to enable more convenient (partial) customization of the loading behavior. Please refer to the JavaDoc for more details and an example.</li>
</ul>

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] ~Feature scope is tested~
- [x] Feature scope is documented
- [x] Release notes are created
