### PR TITLE
Feat: Use Fallback if `SERVICE_BINDING_ROOT` is not defined

### DIFF
--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
@@ -54,6 +54,10 @@ import com.sap.cloud.environment.servicebinding.api.exception.ServiceBindingAcce
  *         ├-- ...
  *         └-- {PROPERTY#N}
  * </pre>
+ *
+ * <b>Note:</b> This class will attempt to read service bindings from {@code /etc/secrets/sapbtp} <b>if</b> the
+ * {@code SERVICE_BINDING_ROOT} environment variable is not defined (i.e.
+ * {@code System.getenv("SERVICE_BINDING_ROOT") == null}).
  */
 public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindingAccessor
 {


### PR DESCRIPTION
## Context

This PR implements a fallback mechanism in case the `SERVICE_BINDING_ROOT` environment variable is **not defined** (affects the `SapServiceOperatorServiceBindingIoAccessor` implementation in module `java-sap-service-operator`).

By default, the mentioned accessor will now try to find service bindings from `/etc/secrets/sapbtp` (same path as the _legacy_ `SapServiceOperatorLayeredServiceBindingAccessor` uses).
With that, updating the SAP Service Operator from versions `< 0.2.3` to newer ones should work without the need to adjust the deployment - more precisely without introducing the `SERVICE_BINDING_ROOT` environment variable in the deployment.

**Note**

The fallback root directory will be considered **only** if the `SERVICE_BINDING_ROOT` environment variable is not defined, i.e. `System.getenv("SERVICE_BINDING_ROOT") == null`.
In all other cases, for example, if the variable is defined but does not point to an existing directory, the fallback **will not be used**.

### Feature Scope

- [x] Implement fallback in case `SERVICE_BINDING_ROOT` is not defined

<details>
<summary><h3>Release Notes</h3></summary>

<h3>Module: <code>java-sap-service-operator</code></h3>

<ul>
<li>The <code>SapServiceOperatorServiceBindingIoAccessor</code> will now try to read service bindings from <code>/etc/secrets/sapbtp</code> in case the <code>SERVICE_BINDING_ROOT</code> environment variable is not define.</li>
</ul>

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] Feature scope is tested
- [x] Feature scope is documented (documented as part of the class JavaDoc)
- [x] Release notes are created
