### PR TITLE
Chore: Use `credentials` as the credentials key in Service Binding IO Bindings

### DIFF
--- a/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingTest.java
+++ b/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingTest.java
@@ -44,8 +44,8 @@ class DefaultServiceBindingTest
         final DefaultServiceBinding sut = DefaultServiceBinding.builder().copy(input).build();
 
         assertThat(sut).isNotNull();
-        assertThat(sut.get("Boolean1").orElse(null)).isEqualTo(true);
-        assertThat(sut.get("Boolean2").orElse(null)).isEqualTo(false);
+        assertThat(sut.get("Boolean1")).hasValue(true);
+        assertThat(sut.get("Boolean2")).hasValue(false);
         assertThat((Iterable<Boolean>) sut.get("Booleans").orElse(null)).containsExactly(true, false);
     }
 
@@ -64,12 +64,12 @@ class DefaultServiceBindingTest
         final DefaultServiceBinding sut = DefaultServiceBinding.builder().copy(input).build();
 
         assertThat(sut).isNotNull();
-        assertThat(sut.get("Byte").orElse(null)).isEqualTo(BYTE);
-        assertThat(sut.get("Integer").orElse(null)).isEqualTo(INTEGER);
-        assertThat(sut.get("Long").orElse(null)).isEqualTo(LONG);
-        assertThat(sut.get("Float").orElse(null)).isEqualTo(FLOAT);
-        assertThat(sut.get("Double").orElse(null)).isEqualTo(DOUBLE);
-        assertThat(sut.get("BigDecimal").orElse(null)).isEqualTo(BIG_DECIMAL);
+        assertThat(sut.get("Byte")).hasValue(BYTE);
+        assertThat(sut.get("Integer")).hasValue(INTEGER);
+        assertThat(sut.get("Long")).hasValue(LONG);
+        assertThat(sut.get("Float")).hasValue(FLOAT);
+        assertThat(sut.get("Double")).hasValue(DOUBLE);
+        assertThat(sut.get("BigDecimal")).hasValue(BIG_DECIMAL);
         assertThat((Iterable<Number>) sut.get("Numbers").orElse(null))
             .containsExactly(BYTE, INTEGER, LONG, FLOAT, DOUBLE, BIG_DECIMAL);
     }
@@ -85,8 +85,8 @@ class DefaultServiceBindingTest
         final DefaultServiceBinding sut = DefaultServiceBinding.builder().copy(input).build();
 
         assertThat(sut).isNotNull();
-        assertThat(sut.get("String1").orElse(null)).isEqualTo("foo");
-        assertThat(sut.get("String2").orElse(null)).isEqualTo("");
+        assertThat(sut.get("String1")).hasValue("foo");
+        assertThat(sut.get("String2")).hasValue("");
         assertThat((Iterable<String>) sut.get("Strings").orElse(null)).containsExactly("foo", "");
     }
 

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
@@ -95,6 +95,9 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
     private static final String PLAN_KEY = "plan";
 
     @Nonnull
+    private static final String DEFAULT_CREDENTIALS_KEY = "credentials";
+
+    @Nonnull
     private final Function<String, String> environmentVariableReader;
 
     @Nonnull
@@ -248,7 +251,7 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
             return null;
         }
 
-        final String credentialsKey = generateNewKey(rawServiceBinding);
+        final String credentialsKey = generateCredentialsKey(rawServiceBinding);
         rawServiceBinding.put(credentialsKey, rawCredentials);
 
         final DefaultServiceBinding serviceBinding =
@@ -390,8 +393,12 @@ public class SapServiceOperatorServiceBindingIoAccessor implements ServiceBindin
     }
 
     @Nonnull
-    private String generateNewKey( @Nonnull final Map<String, Object> map )
+    private String generateCredentialsKey( @Nonnull final Map<String, Object> map )
     {
+        if( !map.containsKey(DEFAULT_CREDENTIALS_KEY) ) {
+            return DEFAULT_CREDENTIALS_KEY;
+        }
+
         for( int i = 0; i < 100; ++i ) {
             final String key = UUID.randomUUID().toString();
             if( map.containsKey(key) ) {

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredDataParsingStrategyTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredDataParsingStrategyTest.java
@@ -33,9 +33,9 @@ class LayeredDataParsingStrategyTest
         assertThat(serviceBinding.getKeys())
             .containsExactlyInAnyOrder("instance_guid", "instance_name", "label", "plan", "tags", "credentials");
 
-        assertThat(serviceBinding.getName().orElse("")).isEqualTo("my-xsuaa-binding");
-        assertThat(serviceBinding.getServiceName().orElse("")).isEqualTo("XSUAA");
-        assertThat(serviceBinding.getServicePlan().orElse("")).isEqualTo("my-plan");
+        assertThat(serviceBinding.getName()).hasValue("my-xsuaa-binding");
+        assertThat(serviceBinding.getServiceName()).hasValue("XSUAA");
+        assertThat(serviceBinding.getServicePlan()).hasValue("my-plan");
         assertThat(serviceBinding.getTags()).containsExactly("my-tag-1", "my-tag-2");
 
         assertThat(serviceBinding.getCredentials()).containsOnlyKeys("domains", "clientid", "clientsecret");

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredSecretKeyParsingStrategyTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredSecretKeyParsingStrategyTest.java
@@ -29,9 +29,9 @@ class LayeredSecretKeyParsingStrategyTest
         final ServiceBinding serviceBinding = sut.parse("XSUAA", "my-xsuaa-binding", path).orElse(null);
 
         assertThat(serviceBinding).isNotNull();
-        assertThat(serviceBinding.getName().orElse("")).isEqualTo("my-xsuaa-binding");
-        assertThat(serviceBinding.getServiceName().orElse("")).isEqualTo("XSUAA");
-        assertThat(serviceBinding.getServicePlan().orElse("")).isEqualTo("my-plan");
+        assertThat(serviceBinding.getName()).hasValue("my-xsuaa-binding");
+        assertThat(serviceBinding.getServiceName()).hasValue("XSUAA");
+        assertThat(serviceBinding.getServicePlan()).hasValue("my-plan");
         assertThat(serviceBinding.getTags()).isEmpty();
 
         assertThat(serviceBinding.getCredentials())

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredSecretRootKeyParsingStrategyTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredSecretRootKeyParsingStrategyTest.java
@@ -53,9 +53,9 @@ class LayeredSecretRootKeyParsingStrategyTest
         final ServiceBinding serviceBinding = sut.parse("XSUAA", "my-xsuaa-binding", path).orElse(null);
 
         assertThat(serviceBinding).isNotNull();
-        assertThat(serviceBinding.getName().orElse("")).isEqualTo("my-xsuaa-binding");
-        assertThat(serviceBinding.getServiceName().orElse("")).isEqualTo("XSUAA");
-        assertThat(serviceBinding.getServicePlan().orElse("")).isEqualTo("lite");
+        assertThat(serviceBinding.getName()).hasValue("my-xsuaa-binding");
+        assertThat(serviceBinding.getServiceName()).hasValue("XSUAA");
+        assertThat(serviceBinding.getServicePlan()).hasValue("lite");
         assertThat(serviceBinding.getTags()).containsExactly("tag1", "tag2");
         assertThat(serviceBinding.getCredentials()).containsKeys("clientid", "clientsecret");
     }

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessorTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessorTest.java
@@ -64,9 +64,9 @@ class SapServiceOperatorLayeredServiceBindingAccessorTest
 
         assertThat(secretRootKeyBinding.getKeys()).containsExactlyInAnyOrder("tags", "plan", "credentials");
 
-        assertThat(secretRootKeyBinding.getName().orElse("")).isEqualTo("secret-root-key-binding");
-        assertThat(secretRootKeyBinding.getServiceName().orElse("")).isEqualTo("xsuaa");
-        assertThat(secretRootKeyBinding.getServicePlan().orElse("")).isEqualTo("secret-root-key-xsuaa-plan");
+        assertThat(secretRootKeyBinding.getName()).hasValue("secret-root-key-binding");
+        assertThat(secretRootKeyBinding.getServiceName()).hasValue("xsuaa");
+        assertThat(secretRootKeyBinding.getServicePlan()).hasValue("secret-root-key-xsuaa-plan");
         assertThat(secretRootKeyBinding.getTags())
             .containsExactly("secret-root-key-xsuaa-tag-1", "secret-root-key-xsuaa-tag-2");
         assertThat(secretRootKeyBinding.getCredentials()).containsKeys("clientid", "clientsecret");
@@ -137,9 +137,9 @@ class SapServiceOperatorLayeredServiceBindingAccessorTest
         assertThat(secretKeyBinding.getKeys())
             .containsExactlyInAnyOrder("instance_guid", "instance_name", "label", "plan", "credentials");
 
-        assertThat(secretKeyBinding.getName().orElse("")).isEqualTo("secret-key-binding");
-        assertThat(secretKeyBinding.getServiceName().orElse("")).isEqualTo("xsuaa");
-        assertThat(secretKeyBinding.getServicePlan().orElse("")).isEqualTo("secret-key-xsuaa-plan");
+        assertThat(secretKeyBinding.getName()).hasValue("secret-key-binding");
+        assertThat(secretKeyBinding.getServiceName()).hasValue("xsuaa");
+        assertThat(secretKeyBinding.getServicePlan()).hasValue("secret-key-xsuaa-plan");
         assertThat(secretKeyBinding.getTags()).isEmpty();
         assertThat(secretKeyBinding.getCredentials())
             .containsOnlyKeys("domain", "domains", "clientid", "clientsecret", "url", "zone_uuid");
@@ -158,9 +158,9 @@ class SapServiceOperatorLayeredServiceBindingAccessorTest
         assertThat(dataBinding.getKeys())
             .containsExactlyInAnyOrder("instance_guid", "instance_name", "label", "plan", "tags", "credentials");
 
-        assertThat(dataBinding.getName().orElse("")).isEqualTo("data-binding");
-        assertThat(dataBinding.getServiceName().orElse("")).isEqualTo("xsuaa");
-        assertThat(dataBinding.getServicePlan().orElse("")).isEqualTo("data-xsuaa-plan");
+        assertThat(dataBinding.getName()).hasValue("data-binding");
+        assertThat(dataBinding.getServiceName()).hasValue("xsuaa");
+        assertThat(dataBinding.getServicePlan()).hasValue("data-xsuaa-plan");
         assertThat(dataBinding.getTags()).containsExactly("data-xsuaa-tag-1", "data-xsuaa-tag-2");
         assertThat(dataBinding.getCredentials()).containsOnlyKeys("domains", "clientid", "clientsecret");
     }

--- a/sap-vcap-services/src/test/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessorTest.java
+++ b/sap-vcap-services/src/test/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessorTest.java
@@ -51,8 +51,8 @@ class SapVcapServicesServiceBindingAccessorTest
 
         assertThat(binding.getKeys()).containsExactlyInAnyOrder("name", "plan", "tags", "credentials");
 
-        assertThat(binding.getName().orElse("")).isEqualTo("xsuaa-binding-1");
-        assertThat(binding.getServicePlan().orElse("")).isEqualTo("lite");
+        assertThat(binding.getName()).hasValue("xsuaa-binding-1");
+        assertThat(binding.getServicePlan()).hasValue("lite");
         assertThat(binding.getTags()).containsExactly("xsuaa-binding-1-tag-1", "xsuaa-binding-1-tag-2");
         assertThat(binding.getCredentials()).containsOnlyKeys("uri", "clientid", "clientsecret");
         assertThat(binding.getCredentials().get("uri")).isEqualTo("https://xsuaa-1.domain.com");
@@ -74,8 +74,8 @@ class SapVcapServicesServiceBindingAccessorTest
 
         assertThat(binding.getKeys()).containsExactlyInAnyOrder("name", "plan", "tags", "credentials");
 
-        assertThat(binding.getName().orElse("")).isEqualTo("xsuaa-binding-2");
-        assertThat(binding.getServicePlan().orElse("")).isEqualTo("application");
+        assertThat(binding.getName()).hasValue("xsuaa-binding-2");
+        assertThat(binding.getServicePlan()).hasValue("application");
         assertThat(binding.getTags()).containsExactly("xsuaa-binding-2-tag-1", "xsuaa-binding-2-tag-2");
         assertThat(binding.getCredentials()).containsOnlyKeys("uri", "clientid", "clientsecret");
         assertThat(binding.getCredentials().get("uri")).isEqualTo("https://xsuaa-2.domain.com");
@@ -97,8 +97,8 @@ class SapVcapServicesServiceBindingAccessorTest
 
         assertThat(binding.getKeys()).containsExactlyInAnyOrder("name", "plan", "tags", "credentials");
 
-        assertThat(binding.getName().orElse("")).isEqualTo("destination-binding-1");
-        assertThat(binding.getServicePlan().orElse("")).isEqualTo("broker");
+        assertThat(binding.getName()).hasValue("destination-binding-1");
+        assertThat(binding.getServicePlan()).hasValue("broker");
         assertThat(binding.getTags()).containsExactly("destination-binding-1-tag-1", "destination-binding-1-tag-2");
         assertThat(binding.getCredentials()).containsOnlyKeys("uri", "clientid", "clientsecret");
         assertThat(binding.getCredentials().get("uri")).isEqualTo("https://destination-1.domain.com");


### PR DESCRIPTION
## Context

This PR makes the internal data structure of `ServiceBinding` instances created by the `SapServiceOperatorServiceBindingIoAccessor` more consistent with the remaining internal structures of other `Accessor` implementations.
In other words: Instead of generating a random `UUID` and using that as the key for the _credentials_ property, the accessor now first tries to use `credentials` as a key.
If that key already exists in the "raw" binding (i.e. in the file system structure), only then is a random `UUID` chosen to avoid name clashes.

### Feature Scope

- [x] Unify internal `ServiceBinding` representation

<details>
<summary><h3>Release Notes</h3></summary>

<h3>Module: <code>java-sap-service-operator</code></h3>

<ul>
<li>The <code>SapServiceOperatorServiceBindingIoAccessor</code> now tries to store the credentials using the key <code>credentials</code> if it is available - otherwise it will keep generating a random <code>UUID</code> to avoid a key name clash</li>
</ul>

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] Feature scope is tested
- [x] ~Feature scope is documented~
- [x] Release notes are created
