### PR TITLE
Feat: Advanced Filtering Capabilities

### DIFF
--- a/api-parent/consumption-api/pom.xml
+++ b/api-parent/consumption-api/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>java-core-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.sap.cloud.environment.servicebinding.api</groupId>
+            <artifactId>java-access-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/CollectionFilterBuilder.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/CollectionFilterBuilder.java
@@ -1,0 +1,74 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public interface CollectionFilterBuilder<T>
+{
+    class Default<T> implements CollectionFilterBuilder<T>
+    {
+        @Nonnull
+        private final ServiceBindingPropertySelector<Collection<T>> propertySelector;
+
+        Default( @Nonnull final ServiceBindingPropertySelector<Collection<T>> propertySelector )
+        {
+            this.propertySelector = propertySelector;
+        }
+
+        @Nonnull
+        @Override
+        public
+            ServiceBindingFilter
+            contains( @Nullable final T item, @Nonnull final EqualityComparison<T> equalityComparison )
+        {
+            return binding -> {
+                @Nullable
+                final Collection<T> maybeItems = propertySelector.select(binding);
+                if( maybeItems == null || maybeItems.isEmpty() ) {
+                    return false;
+                }
+
+                return maybeItems.stream().anyMatch(i -> equalityComparison.areEqual(i, item));
+            };
+        }
+    }
+
+    class StringImpl implements CollectionFilterBuilder<String>
+    {
+        @Nonnull
+        private final Default<String> delegate;
+
+        StringImpl( @Nonnull final ServiceBindingPropertySelector<Collection<String>> propertySelector )
+        {
+            delegate = new Default<>(propertySelector);
+        }
+
+        @Nonnull
+        @Override
+        public
+            ServiceBindingFilter
+            contains( @Nullable final String item, @Nonnull final EqualityComparison<String> equalityComparison )
+        {
+            return delegate.contains(item, equalityComparison);
+        }
+
+        @Nonnull
+        @Override
+        public ServiceBindingFilter contains( @Nullable final String item )
+        {
+            return contains(item, EqualityComparison.String.CASE_INSENSITIVE);
+        }
+    }
+
+    @Nonnull
+    ServiceBindingFilter contains( @Nullable final T item, @Nonnull final EqualityComparison<T> equalityComparison );
+
+    @Nonnull
+    default ServiceBindingFilter contains( @Nullable final T item )
+    {
+        return contains(item, Objects::equals);
+    }
+}

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/EqualityComparison.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/EqualityComparison.java
@@ -1,0 +1,33 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import javax.annotation.Nullable;
+
+@FunctionalInterface
+public interface EqualityComparison<T>
+{
+    final class String
+    {
+        public static EqualityComparison<java.lang.String> CASE_SENSITIVE = ( a, b ) -> {
+            if( a == null || b == null ) {
+                return false;
+            }
+
+            return a.contentEquals(b);
+        };
+
+        public static EqualityComparison<java.lang.String> CASE_INSENSITIVE = ( a, b ) -> {
+            if( a == null || b == null ) {
+                return false;
+            }
+
+            return a.equalsIgnoreCase(b);
+        };
+
+        private String()
+        {
+            throw new IllegalStateException("This static utility class must not be instantiated!");
+        }
+    }
+
+    boolean areEqual( @Nullable final T a, @Nullable final T b );
+}

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/EqualityFilterBuilder.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/EqualityFilterBuilder.java
@@ -1,0 +1,71 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public interface EqualityFilterBuilder<T>
+{
+    class Default<T> implements EqualityFilterBuilder<T>
+    {
+        @Nonnull
+        private final ServiceBindingPropertySelector<T> propertySelector;
+
+        Default( @Nonnull final ServiceBindingPropertySelector<T> propertySelector )
+        {
+            this.propertySelector = propertySelector;
+        }
+
+        @Nonnull
+        @Override
+        public
+            ServiceBindingFilter
+            isEqualTo( @Nullable final T value, @Nonnull final EqualityComparison<T> equalityComparison )
+        {
+            return binding -> equalityComparison.areEqual(propertySelector.select(binding), value);
+        }
+    }
+
+    class StringImpl implements EqualityFilterBuilder<String>
+    {
+        @Nonnull
+        private final Default<String> delegate;
+
+        StringImpl( @Nonnull final ServiceBindingPropertySelector<String> propertySelector )
+        {
+            delegate = new Default<>(propertySelector);
+        }
+
+        @Nonnull
+        @Override
+        public
+            ServiceBindingFilter
+            isEqualTo( @Nullable final String value, @Nonnull final EqualityComparison<String> equalityComparison )
+        {
+            return delegate.isEqualTo(value, equalityComparison);
+        }
+
+        @Nonnull
+        @Override
+        public ServiceBindingFilter isEqualTo( @Nullable final String value )
+        {
+            return isEqualTo(value, EqualityComparison.String.CASE_INSENSITIVE);
+        }
+    }
+
+    @Nonnull
+    ServiceBindingFilter isEqualTo( @Nullable final T value, @Nonnull final EqualityComparison<T> equalityComparison );
+
+    @Nonnull
+    default ServiceBindingFilter isEqualTo( @Nullable final T value )
+    {
+        return isEqualTo(value, Objects::equals);
+    }
+
+    @Nonnull
+    default ServiceBindingFilter isNull()
+    {
+        return isEqualTo(null);
+    }
+}

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/FilteredServiceBindingAccessor.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/FilteredServiceBindingAccessor.java
@@ -1,0 +1,76 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.sap.cloud.environment.servicebinding.api.exception.ServiceBindingAccessException;
+
+public class FilteredServiceBindingAccessor implements ServiceBindingAccessor
+{
+
+    @Nonnull
+    private final ServiceBindingAccessor accessor;
+    @Nonnull
+    private final ServiceBindingFilter filter;
+
+    private FilteredServiceBindingAccessor(
+        @Nonnull final ServiceBindingAccessor accessor,
+        @Nonnull final ServiceBindingFilter filter )
+    {
+        this.accessor = accessor;
+        this.filter = filter;
+    }
+
+    @Nonnull
+    @Override
+    public List<ServiceBinding> getServiceBindings()
+        throws ServiceBindingAccessException
+    {
+        return accessor.getServiceBindings().stream().filter(filter::matches).collect(Collectors.toList());
+    }
+
+    public static Builder from( @Nonnull final ServiceBindingAccessor accessor )
+    {
+        return new BuilderImpl(accessor);
+    }
+
+    interface Builder
+    {
+        @Nonnull
+        Builder where( @Nonnull final ServiceBindingFilter filter );
+
+        @Nonnull
+        FilteredServiceBindingAccessor build();
+    }
+
+    private static class BuilderImpl implements Builder
+    {
+        @Nonnull
+        private final ServiceBindingAccessor accessor;
+        @Nullable
+        private ServiceBindingFilter filter;
+
+        private BuilderImpl( @Nonnull final ServiceBindingAccessor accessor )
+        {
+            this.accessor = accessor;
+        }
+
+        @Nonnull
+        @Override
+        public Builder where( @Nonnull final ServiceBindingFilter filter )
+        {
+            this.filter = this.filter == null ? filter : this.filter.and(filter);
+            return this;
+        }
+
+        @Nonnull
+        @Override
+        public FilteredServiceBindingAccessor build()
+        {
+            return new FilteredServiceBindingAccessor(accessor, filter == null ? ServiceBindingFilter.TRUE : filter);
+        }
+    }
+}

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingFilter.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingFilter.java
@@ -1,0 +1,84 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface ServiceBindingFilter
+{
+    ServiceBindingFilter TRUE = any -> true;
+    ServiceBindingFilter FALSE = any -> false;
+
+    final class And implements ServiceBindingFilter
+    {
+        @Nonnull
+        private final ServiceBindingFilter first;
+        @Nonnull
+        private final ServiceBindingFilter second;
+
+        private And( @Nonnull final ServiceBindingFilter first, @Nonnull final ServiceBindingFilter second )
+        {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public boolean matches( @Nonnull final ServiceBinding serviceBinding )
+        {
+            return first.matches(serviceBinding) && second.matches(serviceBinding);
+        }
+    }
+
+    final class Or implements ServiceBindingFilter
+    {
+        @Nonnull
+        private final ServiceBindingFilter first;
+        @Nonnull
+        private final ServiceBindingFilter second;
+
+        private Or( @Nonnull final ServiceBindingFilter first, @Nonnull final ServiceBindingFilter second )
+        {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public boolean matches( @Nonnull final ServiceBinding serviceBinding )
+        {
+            return first.matches(serviceBinding) || second.matches(serviceBinding);
+        }
+    }
+
+    final class Not implements ServiceBindingFilter
+    {
+        @Nonnull
+        private final ServiceBindingFilter filter;
+
+        private Not( @Nonnull final ServiceBindingFilter filter )
+        {
+            this.filter = filter;
+        }
+
+        @Override
+        public boolean matches( @Nonnull final ServiceBinding serviceBinding )
+        {
+            return !filter.matches(serviceBinding);
+        }
+    }
+
+    boolean matches( @Nonnull final ServiceBinding serviceBinding );
+
+    default ServiceBindingFilter and( @Nonnull final ServiceBindingFilter other )
+    {
+        return new And(this, other);
+    }
+
+    default ServiceBindingFilter or( @Nonnull final ServiceBindingFilter other )
+    {
+        return new Or(this, other);
+    }
+
+    default ServiceBindingFilter not()
+    {
+        return new Not(this);
+    }
+}

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingProperty.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingProperty.java
@@ -1,0 +1,84 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class ServiceBindingProperty
+{
+    public static EqualityFilterBuilder<String> name()
+    {
+        return new EqualityFilterBuilder.StringImpl(binding -> binding.getName().orElse(null));
+    }
+
+    public static EqualityFilterBuilder<String> serviceName()
+    {
+        return new EqualityFilterBuilder.StringImpl(binding -> binding.getServiceName().orElse(null));
+    }
+
+    public static EqualityFilterBuilder<String> servicePlan()
+    {
+        return new EqualityFilterBuilder.StringImpl(binding -> binding.getServicePlan().orElse(null));
+    }
+
+    public static StringCollectionFilterBuilder tags()
+    {
+        return new StringCollectionFilterBuilder(ServiceBinding::getTags);
+    }
+
+    public static final class StringCollectionFilterBuilder
+        implements
+        CollectionFilterBuilder<String>,
+        EqualityFilterBuilder<Collection<String>>
+    {
+        @Nonnull
+        private final CollectionFilterBuilder.StringImpl collectionDelegate;
+        @Nonnull
+        private final EqualityFilterBuilder<Collection<String>> equalityDelegate;
+
+        StringCollectionFilterBuilder(
+            @Nonnull final ServiceBindingPropertySelector<Collection<String>> propertySelector )
+        {
+            collectionDelegate = new CollectionFilterBuilder.StringImpl(propertySelector);
+            equalityDelegate = new EqualityFilterBuilder.Default<>(propertySelector);
+        }
+
+        @Nonnull
+        @Override
+        public
+            ServiceBindingFilter
+            contains( @Nullable final String item, @Nonnull final EqualityComparison<String> equalityComparison )
+        {
+            return collectionDelegate.contains(item, equalityComparison);
+        }
+
+        @Nonnull
+        @Override
+        public ServiceBindingFilter contains( @Nullable final String item )
+        {
+            return collectionDelegate.contains(item);
+        }
+
+        @Nonnull
+        @Override
+        public ServiceBindingFilter isEqualTo(
+            @Nullable final Collection<String> value,
+            @Nonnull final EqualityComparison<Collection<String>> equalityComparison )
+        {
+            return equalityDelegate.isEqualTo(value, equalityComparison);
+        }
+
+        @Nonnull
+        @Override
+        public ServiceBindingFilter isEqualTo( @Nullable final Collection<String> value )
+        {
+            return equalityDelegate.isEqualTo(value);
+        }
+    }
+
+    private ServiceBindingProperty()
+    {
+        throw new IllegalStateException("This static utility class must not be instantiated!");
+    }
+}

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingProperty.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingProperty.java
@@ -7,25 +7,16 @@ import javax.annotation.Nullable;
 
 public final class ServiceBindingProperty
 {
-    public static EqualityFilterBuilder<String> name()
-    {
-        return new EqualityFilterBuilder.StringImpl(binding -> binding.getName().orElse(null));
-    }
+    public static final EqualityFilterBuilder<String> NAME =
+        new EqualityFilterBuilder.StringImpl(binding -> binding.getName().orElse(null));
 
-    public static EqualityFilterBuilder<String> serviceName()
-    {
-        return new EqualityFilterBuilder.StringImpl(binding -> binding.getServiceName().orElse(null));
-    }
+    public static final EqualityFilterBuilder<String> SERVICE_NAME =
+        new EqualityFilterBuilder.StringImpl(binding -> binding.getServiceName().orElse(null));
 
-    public static EqualityFilterBuilder<String> servicePlan()
-    {
-        return new EqualityFilterBuilder.StringImpl(binding -> binding.getServicePlan().orElse(null));
-    }
+    public static final EqualityFilterBuilder<String> SERVICE_PLAN =
+        new EqualityFilterBuilder.StringImpl(binding -> binding.getServicePlan().orElse(null));
 
-    public static StringCollectionFilterBuilder tags()
-    {
-        return new StringCollectionFilterBuilder(ServiceBinding::getTags);
-    }
+    public static final StringCollectionFilterBuilder TAGS = new StringCollectionFilterBuilder(ServiceBinding::getTags);
 
     public static final class StringCollectionFilterBuilder
         implements

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingPropertySelector.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingPropertySelector.java
@@ -1,0 +1,11 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@FunctionalInterface
+public interface ServiceBindingPropertySelector<T>
+{
+    @Nullable
+    T select( @Nonnull final ServiceBinding serviceBinding );
+}

--- a/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/FilteredServiceBindingAccessorTest.java
+++ b/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/FilteredServiceBindingAccessorTest.java
@@ -2,6 +2,8 @@ package com.sap.cloud.environment.servicebinding.api;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,12 +28,28 @@ class FilteredServiceBindingAccessorTest
             FilteredServiceBindingAccessor
                 .from(delegate)
                 .where(
-                    ServiceBindingProperty
-                        .tags()
+                    ServiceBindingProperty.TAGS
                         .contains("tag")
-                        .or(ServiceBindingProperty.serviceName().isEqualTo("servicename")))
+                        .or(ServiceBindingProperty.SERVICE_NAME.isEqualTo("servicename")))
                 .build();
 
         assertThat(sut.getServiceBindings()).containsExactlyInAnyOrder(BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);
+    }
+
+    @Test
+    void testFilterAlternativeUsage()
+    {
+        final ServiceBindingAccessor accessor =
+            () -> Arrays.asList(EMPTY_BINDING, BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);
+
+        final ServiceBindingFilter filter =
+            ServiceBindingProperty.TAGS
+                .contains("tag")
+                .or(ServiceBindingProperty.SERVICE_NAME.isEqualTo("servicename"));
+
+        final List<ServiceBinding> filteredBindings =
+            accessor.getServiceBindings().stream().filter(filter::matches).collect(Collectors.toList());
+
+        assertThat(filteredBindings).containsExactlyInAnyOrder(BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);
     }
 }

--- a/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/FilteredServiceBindingAccessorTest.java
+++ b/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/FilteredServiceBindingAccessorTest.java
@@ -1,0 +1,37 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilteredServiceBindingAccessorTest
+{
+    private static final ServiceBinding EMPTY_BINDING =
+        DefaultServiceBinding.builder().copy(Collections.emptyMap()).build();
+    private static final ServiceBinding BINDING_WITH_TAG =
+        DefaultServiceBinding.builder().copy(Collections.emptyMap()).withTags(Collections.singletonList("Tag")).build();
+    private static final ServiceBinding BINDING_WITH_SERVICE_NAME =
+        DefaultServiceBinding.builder().copy(Collections.emptyMap()).withServiceName("ServiceName").build();
+
+    @Test
+    void testFilterForTagOrServiceName()
+    {
+        final ServiceBindingAccessor delegate =
+            () -> Arrays.asList(EMPTY_BINDING, BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);
+
+        final FilteredServiceBindingAccessor sut =
+            FilteredServiceBindingAccessor
+                .from(delegate)
+                .where(
+                    ServiceBindingProperty
+                        .tags()
+                        .contains("tag")
+                        .or(ServiceBindingProperty.serviceName().isEqualTo("servicename")))
+                .build();
+
+        assertThat(sut.getServiceBindings()).containsExactlyInAnyOrder(BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);
+    }
+}

--- a/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingFilterTest.java
+++ b/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingFilterTest.java
@@ -1,0 +1,40 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static com.sap.cloud.environment.servicebinding.api.ServiceBindingFilter.FALSE;
+import static com.sap.cloud.environment.servicebinding.api.ServiceBindingFilter.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServiceBindingFilterTest
+{
+    private static final ServiceBinding EMPTY_BINDING =
+        DefaultServiceBinding.builder().copy(Collections.emptyMap()).build();
+
+    @Test
+    void testAndMatching()
+    {
+        assertThat(TRUE.and(TRUE).matches(EMPTY_BINDING)).isTrue();
+        assertThat(TRUE.and(FALSE).matches(EMPTY_BINDING)).isFalse();
+        assertThat(FALSE.and(TRUE).matches(EMPTY_BINDING)).isFalse();
+        assertThat(FALSE.and(FALSE).matches(EMPTY_BINDING)).isFalse();
+    }
+
+    @Test
+    void testOrMatching()
+    {
+        assertThat(TRUE.or(TRUE).matches(EMPTY_BINDING)).isTrue();
+        assertThat(TRUE.or(FALSE).matches(EMPTY_BINDING)).isTrue();
+        assertThat(FALSE.or(TRUE).matches(EMPTY_BINDING)).isTrue();
+        assertThat(FALSE.or(FALSE).matches(EMPTY_BINDING)).isFalse();
+    }
+
+    @Test
+    void testNotMatching()
+    {
+        assertThat(TRUE.not().matches(EMPTY_BINDING)).isFalse();
+        assertThat(FALSE.not().matches(EMPTY_BINDING)).isTrue();
+    }
+}

--- a/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingPropertyTest.java
+++ b/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingPropertyTest.java
@@ -1,0 +1,29 @@
+package com.sap.cloud.environment.servicebinding.api;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServiceBindingPropertyTest
+{
+
+    @Test
+    void testStringCollectionComparesCaseInsensitivelyByDefault()
+    {
+        final ServiceBinding binding =
+            DefaultServiceBinding
+                .builder()
+                .copy(Collections.emptyMap())
+                .withTags(Collections.singletonList("Foo"))
+                .build();
+        final ServiceBindingProperty.StringCollectionFilterBuilder sut =
+            new ServiceBindingProperty.StringCollectionFilterBuilder(ServiceBinding::getTags);
+
+        assertThat(sut.contains("foo").matches(binding)).isTrue();
+        assertThat(sut.contains("FOO").matches(binding)).isTrue();
+        assertThat(sut.contains("fOo").matches(binding)).isTrue();
+        assertThat(sut.contains("FoO").matches(binding)).isTrue();
+    }
+}


### PR DESCRIPTION
## Context

Fixes #99 

This PR introduces an advanced filtering API to the `consumption-api` module.
The API allows to build filter conditions in a fluent, type-safe, and convenient way.
It results in an instance of `ServiceBindingAccessor`, which uses an other `ServiceBindingAccessor` instance and applies the configured filter to the `ServiceBinding` instances returned.

Alternatively, the newly introduced `ServiceBindingFilter` API can also be used to just filter a regular `Stream<ServiceBinding>` (see 2nd test method in below example).

Example:

```java
private static final ServiceBinding EMPTY_BINDING =
    DefaultServiceBinding.builder().copy(Collections.emptyMap()).build();
private static final ServiceBinding BINDING_WITH_TAG =
    DefaultServiceBinding.builder().copy(Collections.emptyMap()).withTags(Collections.singletonList("Tag")).build();
private static final ServiceBinding BINDING_WITH_SERVICE_NAME =
    DefaultServiceBinding.builder().copy(Collections.emptyMap()).withServiceName("ServiceName").build();

@Test
void testFilterForTagOrServiceName()
{
    final ServiceBindingAccessor delegate =
        () -> Arrays.asList(EMPTY_BINDING, BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);

    final FilteredServiceBindingAccessor sut =
        FilteredServiceBindingAccessor
            .from(delegate)
            .where(
                ServiceBindingProperty.TAGS
                    .contains("tag")
                    .or(ServiceBindingProperty.SERVICE_NAME.isEqualTo("servicename")))
            .build();

    assertThat(sut.getServiceBindings()).containsExactlyInAnyOrder(BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);
}

@Test
void testFilterAlternativeUsage()
{
    final ServiceBindingAccessor accessor =
        () -> Arrays.asList(EMPTY_BINDING, BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);

    final ServiceBindingFilter filter =
        ServiceBindingProperty.TAGS
            .contains("tag")
            .or(ServiceBindingProperty.SERVICE_NAME.isEqualTo("servicename"));

    final List<ServiceBinding> filteredBindings =
        accessor.getServiceBindings().stream().filter(filter::matches).collect(Collectors.toList());

    assertThat(filteredBindings).containsExactlyInAnyOrder(BINDING_WITH_TAG, BINDING_WITH_SERVICE_NAME);
}
```

### Feature Scope

- [ ] Implement fluent builder API for filters

<details>
<summary><h3>Release Notes</h3></summary>

<TODO: Insert release notes>

</details>

### Definition of Done

- [ ] Feature scope is implemented
- [ ] Feature scope is tested
- [ ] Feature scope is documented
- [ ] Release notes are created
