### PR TITLE
Rollback to slf4j 1.7 for better compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
       - dependency-name: "net.revelc.code.formatter:formatter-maven-plugin" # newer versions require Java > 8
       - dependency-name: "net.revelc.code:impsort-maven-plugin" # newer versions require Java > 8
       - dependency-name: "org.mockito:mockito-core" # newer versions require Java > 8
+      - dependency-name: "org.slf4j:*"
+        update-types: ["version-update:semver-major"] # stay on slf4j 1.x for better compatibility

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -50,7 +50,7 @@
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <assertj-core.version>3.24.2</assertj-core.version>
         <mockito-core.version>4.11.0</mockito-core.version>
-        <slf4j-api.version>2.0.6</slf4j-api.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <slf4j-simple.version>2.0.6</slf4j-simple.version>
+        <slf4j-simple.version>1.7.36</slf4j-simple.version>
 
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>


### PR DESCRIPTION
## Context

Fixes #111 

Rollback to slf4j 1.7 for better compatibility.

### Feature Scope

- [x] Rollback to slf4j 1.7.36
- [x] Prevent Dependabot updates to 2.x

<details>
<summary><h3>Release Notes</h3></summary>

Rollback to slf4j 1.7 for better compatibility.

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] Feature scope is tested
- [ ] Feature scope is documented
- [x] Release notes are created
