### PR TITLE
Feat: Improve Resilience of the `FileSystemWatcherCache`

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -95,6 +95,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj-core.version}</version>

--- a/sap-service-operator/pom.xml
+++ b/sap-service-operator/pom.xml
@@ -47,6 +47,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCache.java
@@ -1,30 +1,38 @@
 /*
- * Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
  */
 
 package com.sap.cloud.environment.servicebinding;
 
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
@@ -33,63 +41,190 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 class FileSystemWatcherCache implements DirectoryBasedCache
 {
     @Nonnull
+    private static final Logger log = LoggerFactory.getLogger(FileSystemWatcherCache.class);
+
+    @Nonnull
+    private static final Supplier<FileSystem> DEFAULT_FILE_SYSTEM_SUPPLIER = FileSystems::getDefault;
+    private static final int DEFAULT_MAX_RECONCILIATION_ATTEMPTS = 3;
+    @Nonnull
     private static final Collection<WatchEvent.Kind<?>> MODIFICATION_EVENTS =
         Arrays.asList(ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
 
     @Nonnull
-    private static final ConcurrentHashMap<FileSystem, WatchService> watchServices = new ConcurrentHashMap<>();
-
+    private static final Lock cachedWatchServicesLock = new ReentrantLock();
     @Nonnull
-    private static WatchService getOrCreateWatchService( @Nonnull final FileSystem fileSystem )
+    private static final Map<FileSystem, AutoClosingWatchService> cachedWatchServices = new HashMap<>();
+
+    @Nullable
+    private static AutoClosingWatchService tryGetOrCreateWatchService( @Nonnull final FileSystem fileSystem )
     {
-        return watchServices.computeIfAbsent(fileSystem, fs -> {
-            try {
-                return fs.newWatchService();
+        if( !fileSystem.isOpen() ) {
+            log
+                .warn(
+                    "Trying to retrieve a {} for a closed {}.",
+                    WatchService.class.getName(),
+                    fileSystem.getClass().getName());
+            return null;
+        }
+
+        cachedWatchServicesLock.lock();
+        try {
+            cachedWatchServices.entrySet().removeIf(entry -> !entry.getKey().isOpen() || entry.getValue().isClosed());
+
+            final AutoClosingWatchService result = cachedWatchServices.computeIfAbsent(fileSystem, key -> {
+                try {
+                    final WatchService watchService = fileSystem.newWatchService();
+                    final AutoClosingWatchService autoClosingWatchService = new AutoClosingWatchService(watchService);
+                    if( autoClosingWatchService.isClosed() ) {
+                        return null;
+                    }
+
+                    return autoClosingWatchService;
+                }
+                catch( final IOException e ) {
+                    log
+                        .warn(
+                            "Unable to create new {} from the provided {}.",
+                            WatchService.class.getName(),
+                            fileSystem.getClass().getName(),
+                            e);
+                    return null;
+                }
+            });
+
+            if( result == null ) {
+                return null;
             }
-            catch( final IOException e ) {
-                throw new IllegalStateException(
-                    String.format("Unable to create new instance of '%s'.", WatchService.class.getSimpleName()),
-                    e);
-            }
-        });
+
+            return result.increaseReferenceCountAndGet();
+        }
+        finally {
+            cachedWatchServicesLock.unlock();
+        }
     }
 
     @Nonnull
-    private final Function<Path, ServiceBinding> serviceBindingLoader;
+    private final Function<Path, ServiceBinding> serviceBindingFromDirectory;
     @Nonnull
-    // package-private for simplified testing
+    private final Supplier<FileSystem> fileSystemSupplier;
+    private final int maxReconciliationAttempts;
+    int reconciliationAttempts = -1;
+    // we are starting at -1 because the very first "reconciliation" attempt is just the lazy initialization, so we don't count that towards the granted limit
+    @Nonnull
     final Map<Path, ServiceBinding> cachedServiceBindings = new HashMap<>();
     @Nonnull
-    // package-private for simplified testing
     final Map<Path, WatchKey> directoryWatchKeys = new HashMap<>();
-    @Nonnull
-    private final WatchService watchService;
+    @Nullable
+    FileSystem fileSystem;
+    @Nullable
+    AutoClosingWatchService watchService;
 
-    public FileSystemWatcherCache( @Nonnull final Function<Path, ServiceBinding> serviceBindingLoader )
+    public FileSystemWatcherCache( @Nonnull final Function<Path, ServiceBinding> serviceBindingFromDirectory )
     {
-        this(serviceBindingLoader, FileSystems.getDefault());
+        this(serviceBindingFromDirectory, DEFAULT_FILE_SYSTEM_SUPPLIER, DEFAULT_MAX_RECONCILIATION_ATTEMPTS);
     }
 
-    FileSystemWatcherCache(
-        @Nonnull final Function<Path, ServiceBinding> serviceBindingLoader,
-        @Nonnull final FileSystem fileSystem )
+    public FileSystemWatcherCache(
+        @Nonnull final Function<Path, ServiceBinding> serviceBindingFromDirectory,
+        @Nonnull final Supplier<FileSystem> fileSystemSupplier,
+        @Nonnegative final int maxReconciliationAttempts )
     {
-        this.serviceBindingLoader = serviceBindingLoader;
-        watchService = getOrCreateWatchService(fileSystem);
+        this.serviceBindingFromDirectory = serviceBindingFromDirectory;
+        this.fileSystemSupplier = fileSystemSupplier;
+        this.maxReconciliationAttempts = maxReconciliationAttempts;
     }
 
     @Nonnull
     @Override
     public synchronized List<ServiceBinding> getServiceBindings( @Nonnull final Collection<Path> directories )
     {
+        if( reconciliationIsNeeded() ) {
+            tryApplyReconciliation();
+        } else {
+            if( reconciliationAttempts > 0 ) {
+                reconciliationAttempts--;
+                log
+                    .debug(
+                        "Reconciliation is not needed. Granting back one reconciliation attempt. New current reconciliation attempt: {}.",
+                        reconciliationAttempts);
+            }
+        }
+
+        if( reconciliationIsNeeded() ) {
+            // reconciliation didn't work. so just return load the service bindings from the file system and (potentially) re-try reconciliation in the next invocation.
+            releaseResources();
+            return directories
+                .stream()
+                .map(serviceBindingFromDirectory)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        }
+
         removeOutdatedWatchKeys(directories);
         removeOutdatedServiceBindings(directories);
-        return directories
-            .stream()
-            .peek(this::renewCachedServiceBindingIfNeeded)
-            .map(cachedServiceBindings::get)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+
+        boolean watchKeyInvalidExceptionCaught = false;
+        final List<ServiceBinding> result = new ArrayList<>();
+        for( final Path directory : directories ) {
+            @Nullable
+            ServiceBinding maybeCachedServiceBinding;
+            try {
+                maybeCachedServiceBinding = renewCachedServiceBindingIfNeeded(directory);
+            }
+            catch( final WatchKeyInvalidException | UnableToWatchDirectoryException e ) {
+                watchKeyInvalidExceptionCaught = true;
+                maybeCachedServiceBinding = serviceBindingFromDirectory.apply(directory);
+            }
+
+            if( maybeCachedServiceBinding != null ) {
+                result.add(maybeCachedServiceBinding);
+            }
+        }
+
+        if( watchKeyInvalidExceptionCaught ) {
+            releaseResources();
+        }
+
+        return result;
+    }
+
+    private boolean reconciliationIsNeeded()
+    {
+        return fileSystem == null || !fileSystem.isOpen() || watchService == null || watchService.isClosed();
+    }
+
+    private void tryApplyReconciliation()
+    {
+        if( reconciliationAttempts >= maxReconciliationAttempts ) {
+            return;
+        }
+
+        reconciliationAttempts++;
+        if( reconciliationAttempts > 0 ) {
+            // we only log for the 2nd attempt onwards because the very first attempt is actually just the initial setup as this class is lazy.
+            log.debug("Trying to apply reconciliation strategy. This is attempt number {}.", reconciliationAttempts);
+        }
+
+        try {
+            fileSystem = fileSystemSupplier.get();
+        }
+        catch( final Exception e ) {
+            log.debug("Unable to retrieve {}.", FileSystem.class.getName(), e);
+            fileSystem = null;
+        }
+
+        if( fileSystem == null || !fileSystem.isOpen() ) {
+            tryCloseWatchService(watchService);
+            watchService = null;
+            return;
+        }
+
+        final WatchService oldWatchService = watchService;
+        watchService = tryGetOrCreateWatchService(fileSystem);
+
+        if( oldWatchService != watchService ) {
+            tryCloseWatchService(oldWatchService);
+        }
     }
 
     private void removeOutdatedWatchKeys( @Nonnull final Collection<Path> directoriesOfInterest )
@@ -109,53 +244,67 @@ class FileSystemWatcherCache implements DirectoryBasedCache
         cachedServiceBindings.keySet().removeIf(key -> !directoriesOfInterest.contains(key));
     }
 
-    private void renewCachedServiceBindingIfNeeded( @Nonnull final Path directory )
+    @Nullable
+    private ServiceBinding renewCachedServiceBindingIfNeeded( @Nonnull final Path directory )
+        throws WatchKeyInvalidException,
+            UnableToWatchDirectoryException
     {
         @Nullable
         final WatchKey watchKey = directoryWatchKeys.get(directory);
         if( watchKey == null ) {
-            watchAndCacheServiceBinding(directory);
-            return;
+            return watchAndCacheServiceBinding(directory);
         }
 
         if( !watchKey.isValid() ) {
-            throw new IllegalStateException(
-                String.format("%s for directory '%s' is invalid.", WatchKey.class.getSimpleName(), directory));
+            log
+                .error(
+                    "{} for directory '{}' is invalid. As a consequence, this service binding will be reloaded from the disk and reconciliation will be trigger for the next attempt to get all service bindings.",
+                    watchKey.getClass().getName(),
+                    directory);
+            throw new WatchKeyInvalidException();
         }
 
         if( hasBeenModified(watchKey) ) {
-            cacheServiceBinding(directory);
+            log.debug("Directory '{}' has been modified. Reloading the service binding.", directory);
+            return cacheServiceBinding(directory);
         }
+
+        log.debug("Directory '{}' has not been modified. Serving the service binding from the cache.", directory);
+        return cachedServiceBindings.get(directory);
     }
 
-    private void watchAndCacheServiceBinding( @Nonnull final Path directory )
+    @Nullable
+    private ServiceBinding watchAndCacheServiceBinding( @Nonnull final Path directory )
+        throws UnableToWatchDirectoryException
     {
         startWatching(directory);
-        cacheServiceBinding(directory);
+        return cacheServiceBinding(directory);
     }
 
-    private void cacheServiceBinding( @Nonnull final Path directory )
+    private void startWatching( @Nonnull final Path directory )
+        throws UnableToWatchDirectoryException
+    {
+        if( watchService == null ) {
+            throw new UnableToWatchDirectoryException();
+        }
+
+        final WatchKey watchKey = watchService.registerWatchKey(directory);
+        directoryWatchKeys.put(directory, watchKey);
+    }
+
+    @Nullable
+    private ServiceBinding cacheServiceBinding( @Nonnull final Path directory )
     {
         cachedServiceBindings.remove(directory);
 
         @Nullable
-        final ServiceBinding serviceBinding = serviceBindingLoader.apply(directory);
+        final ServiceBinding serviceBinding = serviceBindingFromDirectory.apply(directory);
         if( serviceBinding == null ) {
-            return;
+            return null;
         }
 
         cachedServiceBindings.put(directory, serviceBinding);
-    }
-
-    private void startWatching( @Nonnull final Path directory )
-    {
-        try {
-            final WatchKey watchKey = directory.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
-            directoryWatchKeys.put(directory, watchKey);
-        }
-        catch( final IOException e ) {
-            throw new IllegalStateException(String.format("Unable to watch directory '%s'.", directory), e);
-        }
+        return serviceBinding;
     }
 
     private boolean hasBeenModified( @Nonnull final WatchKey watchKey )
@@ -167,9 +316,172 @@ class FileSystemWatcherCache implements DirectoryBasedCache
     }
 
     @Override
-    protected synchronized void finalize()
+    protected void finalize()
+        throws Throwable
+    {
+        super.finalize();
+        releaseResources();
+    }
+
+    synchronized void releaseResources()
     {
         directoryWatchKeys.values().forEach(WatchKey::cancel);
         directoryWatchKeys.clear();
+        cachedServiceBindings.clear();
+
+        tryCloseWatchService(watchService);
+        fileSystem = null;
+        watchService = null;
+    }
+
+    private void tryCloseWatchService( @Nullable final WatchService watchService )
+    {
+        if( watchService == null ) {
+            return;
+        }
+
+        try {
+            watchService.close();
+        }
+        catch( final IOException e ) {
+            // ignored
+        }
+    }
+
+    static class AutoClosingWatchService implements WatchService
+    {
+        @Nullable
+        private WatchService delegate;
+        @Nonnull
+        private final AtomicInteger referenceCount = new AtomicInteger();
+
+        public AutoClosingWatchService( @Nonnull final WatchService delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Nullable
+        public synchronized WatchKey registerWatchKey( @Nonnull final Path path )
+            throws UnableToWatchDirectoryException
+        {
+            if( delegate == null ) {
+                log.warn("Trying to access a closed {}.", getClass().getName());
+                return null;
+            }
+
+            try {
+                return path.register(delegate, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+            }
+            catch( final IOException e ) {
+                log.error("Unable to watch directory '{}'.", path, e);
+                throw new UnableToWatchDirectoryException();
+            }
+        }
+
+        @Nonnull
+        private synchronized AutoClosingWatchService increaseReferenceCountAndGet()
+        {
+            if( delegate == null ) {
+                log.warn("Trying to access a closed {}.", getClass().getName());
+                return this;
+            }
+
+            final int newReferenceCount = referenceCount.incrementAndGet();
+            log
+                .debug(
+                    "Increased reference count to this {}. There are now {} reference(s) to this instance.",
+                    getClass().getName(),
+                    newReferenceCount);
+            return this;
+        }
+
+        private synchronized boolean isClosed()
+        {
+            if( delegate == null ) {
+                return true;
+            }
+
+            try {
+                delegate.poll();
+                return false;
+            }
+            catch( final ClosedWatchServiceException e ) {
+                return true;
+            }
+        }
+
+        @Override
+        public synchronized void close()
+        {
+            if( delegate == null ) {
+                return;
+            }
+
+            final int newReferenceCount = referenceCount.decrementAndGet();
+            log
+                .debug(
+                    "Decreased reference count to this {}. There are now {} reference(s) to this instance.",
+                    getClass().getName(),
+                    newReferenceCount);
+
+            if( newReferenceCount > 0 ) {
+                return;
+            }
+
+            log.debug("Closing {}.", delegate.getClass().getName());
+            try {
+                delegate.close();
+            }
+            catch( final IOException e ) {
+                log.debug("Exception while trying to close a {}.", delegate.getClass().getName(), e);
+            }
+
+            delegate = null;
+        }
+
+        @Override
+        public synchronized WatchKey poll()
+        {
+            if( delegate == null ) {
+                log.warn("Trying to access a closed {}.", getClass().getName());
+                return null;
+            }
+
+            return delegate.poll();
+        }
+
+        @Override
+        public WatchKey poll( final long timeout, final TimeUnit unit )
+            throws InterruptedException
+        {
+            if( delegate == null ) {
+                log.warn("Trying to access a closed {}.", getClass().getName());
+                return null;
+            }
+
+            return delegate.poll(timeout, unit);
+        }
+
+        @Override
+        public synchronized WatchKey take()
+            throws InterruptedException
+        {
+            if( delegate == null ) {
+                log.warn("Trying to access a closed {}.", getClass().getName());
+                return null;
+            }
+
+            return delegate.take();
+        }
+    }
+
+    private static class WatchKeyInvalidException extends Exception
+    {
+        private static final long serialVersionUID = 9070754310573522025L;
+    }
+
+    private static class UnableToWatchDirectoryException extends Exception
+    {
+        private static final long serialVersionUID = -433620100403474102L;
     }
 }

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/FileSystemWatcherCacheTest.java
@@ -1,40 +1,44 @@
 /*
- * Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
  */
 
 package com.sap.cloud.environment.servicebinding;
 
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.annotation.Nonnull;
-
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
-import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,278 +46,500 @@ import static org.mockito.Mockito.when;
 class FileSystemWatcherCacheTest
 {
     @Test
-    void initialLoadWillHitTheFileSystem( @Nonnull @TempDir final Path rootDirectory )
-        throws IOException
-    {
-        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
-        final Path dir = Files.createDirectories(rootDirectory.resolve("dir"));
-
-        final DirectoryBasedCache sut = new FileSystemWatcherCache(mockedLoader);
-        final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(bindings.size()).isEqualTo(1);
-        verify(mockedLoader, times(1)).apply(eq(dir));
-    }
-
-    @Test
-    void subsequentLoadWillHitTheCache( @Nonnull @TempDir final Path rootDirectory )
-        throws IOException
-    {
-        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
-        final Path dir = Files.createDirectories(rootDirectory.resolve("dir"));
-
-        final DirectoryBasedCache sut = new FileSystemWatcherCache(mockedLoader);
-        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(firstBindings.size()).isEqualTo(1);
-        verify(mockedLoader, times(1)).apply(eq(dir));
-
-        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(secondBindings.size()).isEqualTo(1);
-        verify(mockedLoader, times(1)).apply(eq(dir));
-    }
-
-    @Test
     @SuppressWarnings( "unchecked" )
-    void loadWillHitFileSystemWhenFileIsCreated( @Nonnull @TempDir final Path rootDirectory )
+    void getServiceBindingsWillHitFileSystemForTheFirstInvocationOnly( @Nonnull @TempDir final Path root )
         throws IOException
     {
-        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
-        final Path dir = Files.createDirectories(rootDirectory.resolve("dir"));
-
-        final FileSystemWatcherCache sut = new FileSystemWatcherCache(mockedLoader);
-
-        // manually create cache entries
-        sut.cachedServiceBindings.put(dir, mock(ServiceBinding.class));
-
-        final WatchKey mockedWatchKey = mock(WatchKey.class);
-        when(mockedWatchKey.isValid()).thenReturn(true);
-        // file system has not been changed
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.emptyList());
-
-        sut.directoryWatchKeys.put(dir, mockedWatchKey);
-
-        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(firstBindings.size()).isEqualTo(1);
-        // service binding is not reloaded
-        verify(mockedLoader, times(0)).apply(eq(dir));
-        verify(mockedWatchKey, times(1)).pollEvents();
-
-        // mark the file system as changed
-        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
-        when(mockedWatchEvent.kind()).thenReturn(ENTRY_CREATE);
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
-
-        // load again
-        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(secondBindings.size()).isEqualTo(1);
-        // service binding is reloaded
-        verify(mockedLoader, times(1)).apply(eq(dir));
-        verify(mockedWatchKey, times(2)).pollEvents();
-    }
-
-    @Test
-    @SuppressWarnings( "unchecked" )
-    void loadWillHitFileSystemWhenFileIsModified( @Nonnull @TempDir final Path rootDirectory )
-        throws IOException
-    {
-        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
-        final Path dir = Files.createDirectories(rootDirectory.resolve("dir"));
-
-        final FileSystemWatcherCache sut = new FileSystemWatcherCache(mockedLoader);
-
-        // manually create cache entries
-        sut.cachedServiceBindings.put(dir, mock(ServiceBinding.class));
-
-        final WatchKey mockedWatchKey = mock(WatchKey.class);
-        when(mockedWatchKey.isValid()).thenReturn(true);
-        // file system has not been changed
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.emptyList());
-
-        sut.directoryWatchKeys.put(dir, mockedWatchKey);
-
-        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(firstBindings.size()).isEqualTo(1);
-        // service binding is not reloaded
-        verify(mockedLoader, times(0)).apply(eq(dir));
-        verify(mockedWatchKey, times(1)).pollEvents();
-
-        // mark the file system as changed
-        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
-        when(mockedWatchEvent.kind()).thenReturn(ENTRY_MODIFY);
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
-
-        // load again
-        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(secondBindings.size()).isEqualTo(1);
-        // service binding is reloaded
-        verify(mockedLoader, times(1)).apply(eq(dir));
-        verify(mockedWatchKey, times(2)).pollEvents();
-    }
-
-    @Test
-    @SuppressWarnings( "unchecked" )
-    void loadWillHitFileSystemWhenFileIsDeleted( @Nonnull @TempDir final Path rootDirectory )
-        throws IOException
-    {
-        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
-        final Path dir = Files.createDirectories(rootDirectory.resolve("dir"));
-
-        final FileSystemWatcherCache sut = new FileSystemWatcherCache(mockedLoader);
-
-        // manually create cache entries
-        sut.cachedServiceBindings.put(dir, mock(ServiceBinding.class));
-
-        final WatchKey mockedWatchKey = mock(WatchKey.class);
-        when(mockedWatchKey.isValid()).thenReturn(true);
-        // file system has not been changed
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.emptyList());
-
-        sut.directoryWatchKeys.put(dir, mockedWatchKey);
-
-        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(firstBindings.size()).isEqualTo(1);
-        // service binding is not reloaded
-        verify(mockedLoader, times(0)).apply(eq(dir));
-        verify(mockedWatchKey, times(1)).pollEvents();
-
-        // mark the file system as changed
-        final WatchEvent<Path> mockedWatchEvent = (WatchEvent<Path>) mock(WatchEvent.class);
-        when(mockedWatchEvent.kind()).thenReturn(ENTRY_DELETE);
-        when(mockedWatchKey.pollEvents()).thenReturn(Collections.singletonList(mockedWatchEvent));
-
-        // load again
-        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(secondBindings.size()).isEqualTo(1);
-        // service binding is reloaded
-        verify(mockedLoader, times(1)).apply(eq(dir));
-        verify(mockedWatchKey, times(2)).pollEvents();
-    }
-
-    @Test
-    void loadWillRemoveCacheEntry( @Nonnull @TempDir final Path rootDirectory )
-        throws IOException
-    {
-        final Function<Path, ServiceBinding> mockedLoader = mockedServiceBindingLoader();
-        final Path dir1 = Files.createDirectories(rootDirectory.resolve("dir1"));
-        final Path dir2 = Files.createDirectories(rootDirectory.resolve("dir2"));
-
-        final FileSystemWatcherCache sut = new FileSystemWatcherCache(mockedLoader);
-
-        // manually create cache entries
-        sut.cachedServiceBindings.put(dir1, mock(ServiceBinding.class));
-        sut.cachedServiceBindings.put(dir2, mock(ServiceBinding.class));
-
-        final WatchKey mockedWatchKey1 = mock(WatchKey.class);
-        final WatchKey mockedWatchKey2 = mock(WatchKey.class);
-        sut.directoryWatchKeys.put(dir1, mockedWatchKey1);
-        sut.directoryWatchKeys.put(dir2, mockedWatchKey2);
-
-        sut.getServiceBindings(Collections.emptyList());
-
-        assertThat(sut.directoryWatchKeys).isEmpty();
-        assertThat(sut.cachedServiceBindings).isEmpty();
-
-        verify(mockedWatchKey1, times(1)).cancel();
-        verify(mockedWatchKey2, times(1)).cancel();
-    }
-
-    @Test
-    @SuppressWarnings( "unchecked" )
-    void loadWillIgnoreBindingWhenLoaderReturnsNull( @Nonnull @TempDir final Path rootDirectory )
-        throws IOException
-    {
+        final Path bindingRoot = Files.createDirectories(root.resolve("binding"));
         final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
-        when(loader.apply(any())).thenReturn(null);
-
-        final Path dir = Files.createDirectories(rootDirectory.resolve("dir"));
-
-        final DirectoryBasedCache sut = new FileSystemWatcherCache(loader);
-
-        final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(rootDirectory));
-
-        assertThat(bindings.size()).isEqualTo(0);
-        verify(loader, times(1)).apply(eq(dir));
-    }
-
-    @Test
-    @SuppressWarnings( "unchecked" )
-    void watchServiceIsCached()
-        throws Exception
-    {
-        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
-        final FileSystem fileSystemA = mock(FileSystem.class);
-        final FileSystem fileSystemB = mock(FileSystem.class);
-        final WatchService watchService = mock(WatchService.class);
-
-        when(fileSystemA.newWatchService()).thenReturn(watchService);
-        when(fileSystemB.newWatchService()).thenReturn(watchService);
-
-        new FileSystemWatcherCache(loader, fileSystemA);
-        verify(fileSystemA, times(1)).newWatchService();
-
-        new FileSystemWatcherCache(loader, fileSystemA);
-        verify(fileSystemA, times(1)).newWatchService();
-
-        // using a different FileSystem will create a new WatchService
-        new FileSystemWatcherCache(loader, fileSystemB);
-        verify(fileSystemB, times(1)).newWatchService();
-    }
-
-    @Test
-    @SuppressWarnings( "unchecked" )
-    void finalizeCancelsWatchKeys()
-    {
-        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
-        when(loader.apply(any())).thenReturn(null);
-
-        final WatchKey watchKey = mock(WatchKey.class);
+        doReturn(mock(ServiceBinding.class)).when(loader).apply(eq(bindingRoot));
 
         final FileSystemWatcherCache sut = new FileSystemWatcherCache(loader);
 
-        sut.directoryWatchKeys.put(Paths.get("some", "imaginary", "path"), watchKey);
+        final List<ServiceBinding> firstBindings = sut.getServiceBindings(getAllDirectories(root));
+        assertThat(firstBindings).hasSize(1);
+        verify(loader, times(1)).apply(eq(bindingRoot));
+
+        final List<ServiceBinding> secondBindings = sut.getServiceBindings(getAllDirectories(root));
+        assertThat(secondBindings).hasSize(1);
+        assertThat(secondBindings.get(0)).isSameAs(firstBindings.get(0));
+        verify(loader, times(1)).apply(eq(bindingRoot)); // no further invocation
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsTriggersReconciliationIfFileSystemIsClosed( @Nonnull @TempDir final Path root )
+        throws IOException
+    {
+        final Path bindingRoot = Files.createDirectories(root.resolve("binding"));
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(mock(ServiceBinding.class)).when(loader).apply(eq(bindingRoot));
+
+        final FileSystem closedFileSystem = mock(FileSystem.class);
+        when(closedFileSystem.isOpen()).thenReturn(false);
+        final Supplier<FileSystem> fileSystemSupplier = (Supplier<FileSystem>) mock(Supplier.class);
+        doReturn(closedFileSystem).when(fileSystemSupplier).get();
+
+        final int expectedInvocations = 4;
+        final int maxReconciliationAttempts = expectedInvocations - 1;
+        final FileSystemWatcherCache sut =
+            new FileSystemWatcherCache(loader, fileSystemSupplier, maxReconciliationAttempts);
+
+        for( int i = 0; i < expectedInvocations; ++i ) {
+            final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(root));
+            assertThat(bindings).hasSize(1);
+
+            verify(loader, times(i + 1)).apply(eq(bindingRoot));
+            verify(fileSystemSupplier, times(i + 1)).get();
+            verify(closedFileSystem, times(0)).newWatchService();
+        }
+
+        // invoking the method once again will not attempt another reconciliation
+        final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(root));
+        assertThat(bindings).hasSize(1);
+
+        verify(loader, times(expectedInvocations + 1)).apply(eq(bindingRoot));
+        verify(fileSystemSupplier, times(expectedInvocations)).get();
+        verify(closedFileSystem, times(0)).newWatchService();
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsTriggersReconciliationIfWatchServiceIsClosed( @Nonnull @TempDir final Path root )
+        throws IOException
+    {
+        final Path bindingRoot = Files.createDirectories(root.resolve("binding"));
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(mock(ServiceBinding.class)).when(loader).apply(eq(bindingRoot));
+
+        final WatchService closedWatchService = mock(WatchService.class);
+        doThrow(ClosedWatchServiceException.class).when(closedWatchService).poll();
+        final FileSystem fileSystem = mock(FileSystem.class);
+        doReturn(true).when(fileSystem).isOpen();
+        doReturn(closedWatchService).when(fileSystem).newWatchService();
+        final Supplier<FileSystem> fileSystemSupplier = (Supplier<FileSystem>) mock(Supplier.class);
+        doReturn(fileSystem).when(fileSystemSupplier).get();
+
+        final int expectedInvocations = 4;
+        final int maxReconciliationAttempts = expectedInvocations - 1;
+        final FileSystemWatcherCache sut =
+            new FileSystemWatcherCache(loader, fileSystemSupplier, maxReconciliationAttempts);
+
+        for( int i = 0; i < expectedInvocations; ++i ) {
+            final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(root));
+            assertThat(bindings).hasSize(1);
+
+            verify(loader, times(i + 1)).apply(eq(bindingRoot));
+            verify(fileSystemSupplier, times(i + 1)).get();
+            verify(fileSystem, times(i + 1)).newWatchService();
+            verify(closedWatchService, times(i + 1)).poll();
+        }
+
+        // invoking the method once again will not attempt another reconciliation
+        final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(root));
+        assertThat(bindings).hasSize(1);
+
+        verify(loader, times(expectedInvocations + 1)).apply(eq(bindingRoot));
+        verify(fileSystemSupplier, times(expectedInvocations)).get();
+        verify(fileSystem, times(expectedInvocations)).newWatchService();
+        verify(closedWatchService, times(expectedInvocations)).poll();
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsTriggersReconciliationIfWatchServiceCreationFails( @Nonnull @TempDir final Path root )
+        throws IOException
+    {
+        final Path bindingRoot = Files.createDirectories(root.resolve("binding"));
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(mock(ServiceBinding.class)).when(loader).apply(eq(bindingRoot));
+
+        final FileSystem fileSystem = mock(FileSystem.class);
+        doReturn(true).when(fileSystem).isOpen();
+        doThrow(IOException.class).when(fileSystem).newWatchService();
+        final Supplier<FileSystem> fileSystemSupplier = (Supplier<FileSystem>) mock(Supplier.class);
+        doReturn(fileSystem).when(fileSystemSupplier).get();
+
+        final int expectedInvocations = 4;
+        final int maxReconciliationAttempts = expectedInvocations - 1;
+        final FileSystemWatcherCache sut =
+            new FileSystemWatcherCache(loader, fileSystemSupplier, maxReconciliationAttempts);
+
+        for( int i = 0; i < expectedInvocations; ++i ) {
+            final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(root));
+            assertThat(bindings).hasSize(1);
+
+            verify(loader, times(i + 1)).apply(eq(bindingRoot));
+            verify(fileSystemSupplier, times(i + 1)).get();
+            verify(fileSystem, times(i + 1)).newWatchService();
+        }
+
+        // invoking the method once again will not attempt another reconciliation
+        final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(root));
+        assertThat(bindings).hasSize(1);
+
+        verify(loader, times(expectedInvocations + 1)).apply(eq(bindingRoot));
+        verify(fileSystemSupplier, times(expectedInvocations)).get();
+        verify(fileSystem, times(expectedInvocations)).newWatchService();
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsHitsFileSystemIfFileSystemSupplierThrowsException()
+    {
+        final Path bindingRoot = mock(Path.class);
+        final ServiceBinding binding = mock(ServiceBinding.class);
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(binding).when(loader).apply(eq(bindingRoot));
+
+        final Supplier<FileSystem> fileSystemSupplier = (Supplier<FileSystem>) mock(Supplier.class);
+        doThrow(IllegalStateException.class).when(fileSystemSupplier).get();
+
+        final FileSystemWatcherCache sut = new FileSystemWatcherCache(loader, fileSystemSupplier, 3);
+        final List<ServiceBinding> bindings = sut.getServiceBindings(Collections.singletonList(bindingRoot));
+        assertThat(bindings).containsExactly(binding);
+
+        verify(loader, times(1)).apply(eq(bindingRoot));
+        verify(fileSystemSupplier, times(1)).get();
+        assertThat(sut.fileSystem).isNull();
+        assertThat(sut.watchService).isNull();
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsTriggerReconciliationOnFollowingInvocationIfWatchKeyIsInvalid()
+        throws IOException
+    {
+        final WatchKey invalidWatchKey = mockWatchKey(false);
+        final WatchService watchService = mockWatchService(true);
+        final Path bindingRoot = mockPath(invalidWatchKey);
+        final FileSystem fileSystem = mockFileSystem(watchService);
+
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(mock(ServiceBinding.class)).when(loader).apply(eq(bindingRoot));
+        final Supplier<FileSystem> fileSystemSupplier = (Supplier<FileSystem>) mock(Supplier.class);
+        doReturn(fileSystem).when(fileSystemSupplier).get();
+
+        final FileSystemWatcherCache sut = new FileSystemWatcherCache(loader, fileSystemSupplier, 1);
+
+        // first invocation: do lazy initialization
+        {
+            final List<ServiceBinding> bindings = sut.getServiceBindings(Collections.singletonList(bindingRoot));
+            assertThat(bindings).hasSize(1);
+
+            // lazily initialize the file system ...
+            verify(fileSystemSupplier, times(1)).get();
+            verify(fileSystem, times(3)).isOpen();
+            // ... and the watch service.
+            verify(fileSystem, times(1)).newWatchService();
+            verify(watchService, times(2)).poll();
+            // cache the service binding as it is the first invocation ...
+            verify(loader, times(1)).apply(eq(bindingRoot));
+            // ... but don't check the watch key (yet)
+            verify(invalidWatchKey, times(0)).isValid();
+            // also don't release any resources
+            verify(invalidWatchKey, times(0)).cancel();
+            verify(watchService, times(0)).close();
+        }
+
+        // second invocation: check if watch key is valid
+        {
+            final List<ServiceBinding> bindings = sut.getServiceBindings(Collections.singletonList(bindingRoot));
+            assertThat(bindings).hasSize(1);
+
+            // check whether reconciliation is needed
+            verify(fileSystem, times(5)).isOpen();
+            verify(watchService, times(4)).poll();
+
+            // watch key became invalid...
+            verify(invalidWatchKey, times(1)).isValid();
+            // ... therefore, we will reload the service binding from the file system ...
+            verify(loader, times(2)).apply(eq(bindingRoot));
+            // ... and release all resources afterward
+            verify(invalidWatchKey, times(1)).cancel();
+            verify(watchService, times(1)).close();
+        }
+
+        // third invocation: trigger reconciliation as the previous attempt released all resources
+        {
+            final List<ServiceBinding> bindings = sut.getServiceBindings(Collections.singletonList(bindingRoot));
+            assertThat(bindings).hasSize(1);
+
+            // re-create the file system ...
+            verify(fileSystemSupplier, times(2)).get();
+            verify(fileSystem, times(9)).isOpen();
+            // ... and the watch service.
+            verify(fileSystem, times(2)).newWatchService();
+            verify(watchService, times(6)).poll();
+
+            // cache the service binding as it has been removed from the cache ...
+            verify(loader, times(3)).apply(eq(bindingRoot));
+            // ... but don't check the watch key again
+            verify(invalidWatchKey, times(1)).isValid();
+            // also don't release any resources
+            verify(invalidWatchKey, times(1)).cancel();
+            verify(watchService, times(1)).close();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource( "watchEventTypes" )
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsReloadsIndividualBindingIfDirectoryHasBeenModified(
+        @Nonnull final WatchEvent.Kind<Path> eventKind )
+        throws IOException
+    {
+        final WatchKey firstWatchKey = mockWatchKey(true);
+        final WatchKey secondWatchKey = mockWatchKey(true);
+
+        final Path firstBindingRoot = mockPath(firstWatchKey);
+        final Path secondBindingRoot = mockPath(secondWatchKey);
+
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(mock(ServiceBinding.class)).when(loader).apply(any());
+
+        final FileSystemWatcherCache sut = new FileSystemWatcherCache(loader);
+        final ServiceBinding initialFirstBinding = mock(ServiceBinding.class);
+        final ServiceBinding initialSecondBinding = mock(ServiceBinding.class);
+        sut.cachedServiceBindings.put(firstBindingRoot, initialFirstBinding);
+        sut.directoryWatchKeys.put(firstBindingRoot, firstWatchKey);
+        sut.cachedServiceBindings.put(secondBindingRoot, initialSecondBinding);
+        sut.directoryWatchKeys.put(secondBindingRoot, secondWatchKey);
+
+        // first invocation: all bindings are served from the cache
+        {
+            final List<ServiceBinding> bindings =
+                sut.getServiceBindings(Arrays.asList(firstBindingRoot, secondBindingRoot));
+            assertThat(bindings).hasSize(2);
+            assertThat(bindings).containsExactlyInAnyOrder(initialFirstBinding, initialSecondBinding);
+
+            verifyIsPolled(firstWatchKey, 1);
+            verifyIsPolled(secondWatchKey, 1);
+
+            verify(loader, times(0)).apply(any());
+        }
+
+        // second invocation: one watch key reports new events
+        {
+            final WatchEvent<Path> modificationEvent = (WatchEvent<Path>) mock(WatchEvent.class);
+            doReturn(eventKind).when(modificationEvent).kind();
+            doReturn(Collections.singletonList(modificationEvent)).when(firstWatchKey).pollEvents();
+
+            final List<ServiceBinding> bindings =
+                sut.getServiceBindings(Arrays.asList(firstBindingRoot, secondBindingRoot));
+            assertThat(bindings).hasSize(2);
+            assertThat(bindings).contains(initialSecondBinding).doesNotContain(initialFirstBinding);
+
+            verifyIsPolled(firstWatchKey, 2);
+            verifyIsPolled(secondWatchKey, 2);
+
+            verify(loader, times(1)).apply(eq(firstBindingRoot));
+            verify(loader, times(0)).apply(eq(secondBindingRoot));
+        }
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsGraduallyRecoversReconciliationAttempts()
+        throws IOException
+    {
+        final WatchKey watchKey = mockWatchKey(true);
+        final Path bindingRoot = mockPath(watchKey);
+        final WatchService watchService = mockWatchService(true);
+        final FileSystem fileSystem = mockFileSystem(watchService);
+        final ServiceBinding binding = mock(ServiceBinding.class);
+
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(null).when(loader).apply(eq(bindingRoot));
+
+        final FileSystemWatcherCache sut = new FileSystemWatcherCache(loader, () -> fileSystem, 3);
+
+        // put the cache in a state where everything is fine, but it already applied reconciliation more than once
+        sut.fileSystem = fileSystem;
+        sut.watchService = new FileSystemWatcherCache.AutoClosingWatchService(watchService);
+        sut.directoryWatchKeys.put(bindingRoot, watchKey);
+        sut.cachedServiceBindings.put(bindingRoot, binding);
+        sut.reconciliationAttempts = 2;
+
+        final List<ServiceBinding> bindings = sut.getServiceBindings(Collections.singletonList(bindingRoot));
+        assertThat(bindings).containsExactly(binding); // binding is served from cache
+
+        verify(loader, times(0)).apply(any());
+        assertThat(sut.reconciliationAttempts).isEqualTo(1);
+
+        sut.getServiceBindings(Collections.singletonList(bindingRoot));
+        assertThat(sut.reconciliationAttempts).isEqualTo(0);
+
+        sut.getServiceBindings(Collections.singletonList(bindingRoot));
+        assertThat(sut.reconciliationAttempts).isEqualTo(0); // getting the bindings again won't decrease the reconciliation attempts below 0
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsIgnoresNullResults( @Nonnull @TempDir final Path root )
+        throws IOException
+    {
+        final Path bindingRoot = Files.createDirectories(root.resolve("binding"));
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(null).when(loader).apply(eq(bindingRoot));
+
+        final FileSystemWatcherCache sut = new FileSystemWatcherCache(loader);
+        final List<ServiceBinding> bindings = sut.getServiceBindings(getAllDirectories(root));
+        assertThat(bindings).isEmpty();
+
+        verify(loader, times(1)).apply(eq(bindingRoot));
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    void getServiceBindingsRemovesOutdatedBinding()
+        throws IOException
+    {
+        final WatchKey watchKey = mockWatchKey(true);
+        final Path bindingPath = mockPath(watchKey);
+        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
+        doReturn(null).when(loader).apply(any());
+
+        final FileSystemWatcherCache sut = new FileSystemWatcherCache(loader);
+        sut.cachedServiceBindings.put(bindingPath, mock(ServiceBinding.class));
+        sut.directoryWatchKeys.put(bindingPath, watchKey);
+
+        final List<ServiceBinding> bindings = sut.getServiceBindings(Collections.emptyList());
+        assertThat(bindings).isEmpty();
+        assertThat(sut.cachedServiceBindings).isEmpty();
+        assertThat(sut.directoryWatchKeys).isEmpty();
+
+        verify(watchKey, times(1)).cancel();
+        verify(loader, times(0)).apply(any());
+    }
+
+    @Test
+    void finalizeCallsReleaseResources()
+        throws Throwable
+    {
+        final FileSystemWatcherCache sut = spy(new FileSystemWatcherCache(any -> null));
 
         sut.finalize();
 
-        verify(watchKey, times(1)).cancel();
-        assertThat(sut.directoryWatchKeys).isEmpty();
+        verify(sut, times(1)).releaseResources();
     }
 
-    @Disabled( "This test doesn't work reliably in the CI/CD pipeline. It can still be used for manual testing." )
     @Test
-    @SuppressWarnings( "unchecked" )
-    void watchKeysAreCancelledOnGcRun()
+    void releaseResourcesClosesAllResources()
+        throws IOException
     {
-        final Function<Path, ServiceBinding> loader = (Function<Path, ServiceBinding>) mock(Function.class);
-        when(loader.apply(any())).thenReturn(null);
+        final WatchKey watchKey = mockWatchKey(false);
+        final Path bindingPath = mockPath(watchKey);
+        final WatchService watchService = mockWatchService(true);
+        final FileSystem fileSystem = mockFileSystem(watchService);
 
-        final WatchKey watchKey = mock(WatchKey.class);
+        final FileSystemWatcherCache sut = new FileSystemWatcherCache(any -> null, () -> fileSystem, 3);
+        sut.fileSystem = fileSystem;
+        sut.watchService = new FileSystemWatcherCache.AutoClosingWatchService(watchService);
+        sut.cachedServiceBindings.put(bindingPath, mock(ServiceBinding.class));
+        sut.directoryWatchKeys.put(bindingPath, watchKey);
 
-        FileSystemWatcherCache sut = new FileSystemWatcherCache(loader);
+        sut.releaseResources();
 
-        sut.directoryWatchKeys.put(Paths.get("some", "imaginary", "path"), watchKey);
+        assertThat(sut.cachedServiceBindings).isEmpty();
+        assertThat(sut.directoryWatchKeys).isEmpty();
+        assertThat(sut.fileSystem).isNull();
+        assertThat(sut.watchService).isNull();
 
-        sut = null;
-
-        System.gc();
         verify(watchKey, times(1)).cancel();
+        verify(watchService, times(1)).close();
+    }
+
+    @Test
+    void testReleaseResourcesDoesNotReleaseWatchServiceIfAnotherReferenceExists()
+        throws IOException
+    {
+        final WatchKey watchKey = mockWatchKey(true);
+        final Path bindingPath = mockPath(watchKey);
+        final WatchService watchService = mockWatchService(true);
+        final FileSystem fileSystem = mockFileSystem(watchService);
+
+        final FileSystemWatcherCache sut = new FileSystemWatcherCache(any -> null, () -> fileSystem, 3);
+        sut.getServiceBindings(Collections.singletonList(bindingPath)); // make sure everything has been initialized
+
+        final FileSystemWatcherCache anotherCacheInstance =
+            new FileSystemWatcherCache(any -> null, () -> fileSystem, 3);
+        anotherCacheInstance.getServiceBindings(Collections.singletonList(bindingPath)); // make sure everything has been initialized
+
+        assertThat(sut.watchService).isSameAs(anotherCacheInstance.watchService).isNotNull();
+
+        sut.releaseResources();
+
+        assertThat(sut.fileSystem).isNull();
+        assertThat(sut.watchService).isNull();
+        verify(watchService, times(0)).close(); // watch service has not yet been closed
+
+        anotherCacheInstance.releaseResources();
+
+        assertThat(anotherCacheInstance.fileSystem).isNull();
+        assertThat(anotherCacheInstance.watchService).isNull();
+        verify(watchService, times(1)).close();
     }
 
     @Nonnull
-    @SuppressWarnings( "unchecked" )
-    private static Function<Path, ServiceBinding> mockedServiceBindingLoader()
+    private static Stream<WatchEvent.Kind<Path>> watchEventTypes()
     {
-        final Function<Path, ServiceBinding> mock = (Function<Path, ServiceBinding>) mock(Function.class);
-        when(mock.apply(any())).thenReturn(mock(ServiceBinding.class));
+        return Stream.of(ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+    }
 
-        return mock;
+    @Nonnull
+    private static WatchKey mockWatchKey( final boolean isValid )
+    {
+        final WatchKey watchKey = mock(WatchKey.class);
+        doReturn(isValid).when(watchKey).isValid();
+        doReturn(Collections.emptyList()).when(watchKey).pollEvents();
+        doReturn(true).when(watchKey).reset();
+        doNothing().when(watchKey).cancel();
+
+        return watchKey;
+    }
+
+    @Nonnull
+    private static Path mockPath( @Nonnull final WatchKey watchKey )
+        throws IOException
+    {
+        final Path path = mock(Path.class);
+        doReturn(watchKey).when(path).register(any(), any());
+
+        return path;
+    }
+
+    @Nonnull
+    private static WatchService mockWatchService( final boolean isOpen )
+        throws IOException
+    {
+        final WatchService watchService = mock(WatchService.class);
+        doNothing().when(watchService).close();
+
+        if( isOpen ) {
+            doReturn(null).when(watchService).poll();
+        } else {
+            doThrow(ClosedWatchServiceException.class).when(watchService).poll();
+        }
+
+        return watchService;
+    }
+
+    @Nonnull
+    private static FileSystem mockFileSystem( @Nonnull final WatchService watchService )
+        throws IOException
+    {
+        final FileSystem fileSystem = mock(FileSystem.class);
+        doReturn(true).when(fileSystem).isOpen();
+        doReturn(watchService).when(fileSystem).newWatchService();
+
+        return fileSystem;
+    }
+
+    private static void verifyIsPolled( @Nonnull final WatchKey watchKey, int expectedTimes )
+    {
+        verify(watchKey, times(expectedTimes)).reset();
+        verify(watchKey, times(expectedTimes)).pollEvents();
     }
 
     @Nonnull


### PR DESCRIPTION
## Context

Continuation of #129 

This PR changes the `FileSystemWatcherCache` so that it stops throwing an `IllegalStateException` upon encountering a `WatchKey` that is invalid.
Instead, the cache will try to reconciliation from the issue by re-establishing itself.
If that strategy fails for a configurable (default: `3`) amount of consecutive tries, the cache will disable itself, resulting in always reading the service bindings from the file system.
Additionally, consecutive successes of using the cache will "refill" the amount of available reconciliation attempts.

That way, the cache can stay intact even if the underlying service bindings are being rotated (somewhat) frequently.

### Feature Scope

- [x] Refactor the internal `FileSystemWatcherCache` implementation

<details>
<summary><h3>Release Notes</h3></summary>

## Module: `java-sap-service-operator`

* The internal file system-based cache has been improved to be more resilient. That especially means that the cache no longer throws an `IllegalStateException` if one of the internally used `WatchKey` instances becomes invalid.
  * _Note:_ If the cache fails to establish a `WatchService` (for whatever reason) for too many consecutive times, it will stop trying and disable itself. Following executions will then always be served from the file system.

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] Feature scope is tested
- [x] ~Feature scope is documented~ (internal implementation detail)
- [x] Release notes are created
