### PR TITLE
Make `jsr305` dependency optional

### DIFF
--- a/api-parent/access-api/pom.xml
+++ b/api-parent/access-api/pom.xml
@@ -20,10 +20,6 @@
             <artifactId>java-core-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/api-parent/consumption-api/pom.xml
+++ b/api-parent/consumption-api/pom.xml
@@ -19,10 +19,6 @@
             <groupId>com.sap.cloud.environment.servicebinding.api</groupId>
             <artifactId>java-core-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
 
         <!-- Scope: Test -->
         <dependency>

--- a/api-parent/core-api/pom.xml
+++ b/api-parent/core-api/pom.xml
@@ -14,11 +14,6 @@
     </properties>
 
     <dependencies>
-        <!-- Scope: Compile -->
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
 
         <!-- Scope: Test -->
         <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -45,7 +45,6 @@
 
     <properties>
         <cloud-environment.version>0.6.0</cloud-environment.version>
-        <jsr305.version>3.0.2</jsr305.version>
         <org.json.version>20230618</org.json.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
         <assertj-core.version>3.24.2</assertj-core.version>
@@ -65,11 +64,6 @@
             </dependency>
 
             <!-- Scope: Compile -->
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${jsr305.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
         <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <jsr305.version>3.0.2</jsr305.version>
     </properties>
 
     <dependencyManagement>
@@ -102,6 +103,16 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <!-- for @Nonnull and @Nullable annotations, not required transitively -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${jsr305.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
 
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
+        <jsr305.version>3.0.2</jsr305.version>
         <slf4j-simple.version>2.0.7</slf4j-simple.version>
 
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
@@ -80,7 +81,6 @@
         <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
         <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
-        <jsr305.version>3.0.2</jsr305.version>
     </properties>
 
     <dependencyManagement>
@@ -105,6 +105,7 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Scope: Compile -->
         <!-- for @Nonnull and @Nullable annotations, not required transitively -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/sap-service-operator/pom.xml
+++ b/sap-service-operator/pom.xml
@@ -23,10 +23,6 @@
             <artifactId>java-access-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
         </dependency>

--- a/sap-vcap-services/pom.xml
+++ b/sap-vcap-services/pom.xml
@@ -23,10 +23,6 @@
             <artifactId>java-access-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
         </dependency>


### PR DESCRIPTION
## Context

Dependency `com.google.code.findbugs:jsr305` is used for its annotations to declare local API elements as `@Nonnull` or `@Nullable`.

It's not necessary to declare the dependency transitively for consumers. In fact some scanners flag the dependency as outdated or unmaintained unfortunately.

### Feature Scope

- [x] Move `jsr305` out from `java-bom` pom.
- [x] Declare `jsr305` with optional flag on parent pom.

<details>
<summary><h3>Release Notes</h3></summary>

Dependency `com.google.code.findbugs:jsr305` is no longer declared in `java-bom` nor propagated transitively to consuming Maven projects.

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] Feature scope is tested
- [x] Feature scope is documented
- [x] Release notes are created
