### PR TITLE
Feat: Add the _"wither"_ Pattern to `ServiceBinding`

### DIFF
--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBinding.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBinding.java
@@ -139,7 +139,15 @@ public class DefaultServiceBinding implements ServiceBinding
     @Override
     public int hashCode()
     {
-        return Objects.hash(getName(), getServiceName(), getServicePlan(), getTags(), getCredentials(), properties);
+        return Objects
+            .hash(
+                getName(),
+                getServiceName(),
+                getServiceIdentifier(),
+                getServicePlan(),
+                getTags(),
+                getCredentials(),
+                properties);
     }
 
     @Override
@@ -157,6 +165,7 @@ public class DefaultServiceBinding implements ServiceBinding
         return getName().equals(that.getName())
             && getServiceName().equals(that.getServiceName())
             && getServicePlan().equals(that.getServicePlan())
+            && getServiceIdentifier().equals(that.getServiceIdentifier())
             && getTags().equals(that.getTags())
             && getCredentials().equals(that.getCredentials())
             && properties.equals(that.properties);

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingBuilder.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingBuilder.java
@@ -65,7 +65,7 @@ public class DefaultServiceBindingBuilder
     }
 
     @Nonnull
-    private static Map<String, Object> copyMap(
+    static Map<String, Object> copyMap(
         @Nonnull final Map<String, Object> map,
         @Nonnull final Function<Map<String, Object>, Map<String, Object>> mapDecorator,
         @Nonnull final Function<List<Object>, List<Object>> listDecorator )

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DelegatingServiceBinding.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DelegatingServiceBinding.java
@@ -19,6 +19,18 @@ class DelegatingServiceBinding implements ServiceBinding
 {
     @Nonnull
     private final ServiceBinding delegate;
+
+    // CAUTION:
+    // We are consciously violating multiple best-practices in the code below:
+    // 1. You shouldn't use `Optional` as a field type.
+    // 2. You shouldn't use `@Nullable Optional` anywhere.
+    //
+    // We are still doing it because we need a way to distinguish between these cases:
+    // 1. The user doesn't want to change a property. It should be delegated instead (symbolized by `null`).
+    // 2. The user wants to set a property explicitly to `null` (i.e. they want to "delete" a property from the Service Binding, symbolized by `Optional.empty()`).
+    // 3. The user wants to set a property to a specific value (i.e. they want to "overwrite" a property, symbolized by `Optional.of(value)`).
+    //
+    // We could have used `@Nonnull Optional<Optional<...>>` instead, but that would have been even worse in my opinion.
     @Nullable
     private final Optional<Map<String, Object>> properties;
     @Nullable

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DelegatingServiceBinding.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DelegatingServiceBinding.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
+ */
+
+package com.sap.cloud.environment.servicebinding.api;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+@SuppressWarnings( { "OptionalUsedAsFieldOrParameterType", "OptionalContainsCollection" } )
+class DelegatingServiceBinding implements ServiceBinding
+{
+    @Nonnull
+    private final ServiceBinding delegate;
+    @Nullable
+    private final Optional<Map<String, Object>> properties;
+    @Nullable
+    private final Optional<String> name;
+    @Nullable
+    private final Optional<String> serviceName;
+    @Nullable
+    private final Optional<ServiceIdentifier> serviceIdentifier;
+    @Nullable
+    private final Optional<String> servicePlan;
+    @Nullable
+    private final Optional<List<String>> tags;
+    @Nullable
+    private final Optional<Map<String, Object>> credentials;
+
+    DelegatingServiceBinding(
+        @Nonnull final ServiceBinding delegate,
+        @Nullable final Optional<Map<String, Object>> properties,
+        @Nullable final Optional<String> name,
+        @Nullable final Optional<String> serviceName,
+        @Nullable final Optional<ServiceIdentifier> serviceIdentifier,
+        @Nullable final Optional<String> servicePlan,
+        @Nullable final Optional<List<String>> tags,
+        @Nullable final Optional<Map<String, Object>> credentials )
+    {
+        this.delegate = delegate;
+        this.properties = properties;
+        this.name = name;
+        this.serviceName = serviceName;
+        this.serviceIdentifier = serviceIdentifier;
+        this.servicePlan = servicePlan;
+        this.tags = tags;
+        this.credentials = credentials;
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getKeys()
+    {
+        if( properties == null ) {
+            // the `properties` have NOT been modified
+            return delegate.getKeys();
+        }
+
+        if( !properties.isPresent() ) {
+            // the `properties` have been set EXPLICITLY to `null`
+            return Collections.emptySet();
+        }
+
+        // the `properties` have been EXPLICITLY overwritten
+        return Collections.unmodifiableSet(properties.get().keySet());
+    }
+
+    @Override
+    public boolean containsKey( @Nonnull String key )
+    {
+        return getKeys().contains(key);
+    }
+
+    @Nonnull
+    @Override
+    public Optional<Object> get( @Nonnull String key )
+    {
+        if( properties == null ) {
+            // the `properties` have NOT been modified
+            return delegate.get(key);
+        }
+
+        if( !properties.isPresent() ) {
+            // the `properties` have been set EXPLICITLY to `null`
+            return Optional.empty();
+        }
+
+        // the `properties` have been EXPLICITLY overwritten
+        return Optional.ofNullable(properties.get().get(key));
+    }
+
+    @Nonnull
+    @Override
+    public Optional<String> getName()
+    {
+        if( name == null ) {
+            // the `name` has NOT been modified
+            return delegate.getName();
+        }
+
+        return name;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<String> getServiceName()
+    {
+        if( serviceName == null ) {
+            // the `serviceName` has NOT been modified
+            return delegate.getServiceName();
+        }
+
+        return serviceName;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<ServiceIdentifier> getServiceIdentifier()
+    {
+        if( serviceIdentifier == null ) {
+            // the `serviceIdentifier` has NOT been modified
+            return delegate.getServiceIdentifier();
+        }
+
+        return serviceIdentifier;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<String> getServicePlan()
+    {
+        if( servicePlan == null ) {
+            // the `servicePlan` has NOT been modified
+            return delegate.getServicePlan();
+        }
+
+        return servicePlan;
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getTags()
+    {
+        if( tags == null ) {
+            // the `tags` have NOT been modified
+            return delegate.getTags();
+        }
+
+        if( !tags.isPresent() ) {
+            // the `tags` have been set EXPLICITLY to `null`
+            return Collections.emptyList();
+        }
+
+        return Collections.unmodifiableList(tags.get());
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> getCredentials()
+    {
+        if( credentials == null ) {
+            // the `credentials` have NOT been modified
+            return delegate.getCredentials();
+        }
+
+        if( !credentials.isPresent() ) {
+            // the `credentials` have been set EXPLICITLY to `null`
+            return Collections.emptyMap();
+        }
+
+        return Collections.unmodifiableMap(credentials.get());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects
+            .hash(
+                getName(),
+                getServiceName(),
+                getServiceIdentifier(),
+                getServicePlan(),
+                getTags(),
+                getCredentials(),
+                properties);
+    }
+
+    @Override
+    public boolean equals( final Object o )
+    {
+        if( this == o ) {
+            return true;
+        }
+        if( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        final DelegatingServiceBinding that = (DelegatingServiceBinding) o;
+
+        return getName().equals(that.getName())
+            && getServiceName().equals(that.getServiceName())
+            && getServicePlan().equals(that.getServicePlan())
+            && getServiceIdentifier().equals(that.getServiceIdentifier())
+            && getTags().equals(that.getTags())
+            && getCredentials().equals(that.getCredentials())
+            && Objects.equals(properties, that.properties);
+    }
+
+    @Nonnull
+    static Builder builder( @Nonnull final ServiceBinding delegate )
+    {
+        return new Builder(delegate);
+    }
+
+    static class Builder
+    {
+        @Nonnull
+        private final ServiceBinding delegate;
+        @Nullable
+        private Optional<Map<String, Object>> properties;
+        @Nullable
+        private Optional<String> name;
+        @Nullable
+        private Optional<String> serviceName;
+        @Nullable
+        private Optional<ServiceIdentifier> serviceIdentifier;
+        @Nullable
+        private Optional<String> servicePlan;
+        @Nullable
+        private Optional<List<String>> tags;
+        @Nullable
+        private Optional<Map<String, Object>> credentials;
+
+        Builder( @Nonnull final ServiceBinding delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Nonnull
+        Builder withProperties( @Nullable final Map<String, Object> properties )
+        {
+            @Nullable
+            final Map<String, Object> copiedProperties;
+            if( properties == null ) {
+                copiedProperties = null;
+            } else {
+                copiedProperties =
+                    DefaultServiceBindingBuilder
+                        .copyMap(properties, Collections::unmodifiableMap, Collections::unmodifiableList);
+            }
+
+            this.properties = Optional.ofNullable(copiedProperties);
+            return this;
+        }
+
+        @Nonnull
+        Builder withName( @Nullable final String name )
+        {
+            this.name = Optional.ofNullable(name);
+            return this;
+        }
+
+        @Nonnull
+        Builder withServiceName( @Nullable final String serviceName )
+        {
+            this.serviceName = Optional.ofNullable(serviceName);
+            return this;
+        }
+
+        @Nonnull
+        Builder withServiceIdentifier( @Nullable final ServiceIdentifier serviceIdentifier )
+        {
+            this.serviceIdentifier = Optional.ofNullable(serviceIdentifier);
+            return this;
+        }
+
+        @Nonnull
+        Builder withServicePlan( @Nullable final String servicePlan )
+        {
+            this.servicePlan = Optional.ofNullable(servicePlan);
+            return this;
+        }
+
+        @Nonnull
+        Builder withTags( @Nullable final List<String> tags )
+        {
+            @Nullable
+            final List<String> copiedTags;
+            if( tags == null ) {
+                copiedTags = null;
+            } else {
+                copiedTags = new ArrayList<>(tags);
+            }
+
+            this.tags = Optional.ofNullable(copiedTags);
+            return this;
+        }
+
+        @Nonnull
+        Builder withCredentials( @Nullable final Map<String, Object> credentials )
+        {
+            @Nullable
+            final Map<String, Object> copiedCredentials;
+            if( credentials == null ) {
+                copiedCredentials = null;
+            } else {
+                copiedCredentials =
+                    DefaultServiceBindingBuilder
+                        .copyMap(credentials, Collections::unmodifiableMap, Collections::unmodifiableList);
+            }
+
+            this.credentials = Optional.ofNullable(copiedCredentials);
+            return this;
+        }
+
+        @Nonnull
+        ServiceBinding build()
+        {
+            return new DelegatingServiceBinding(
+                delegate,
+                properties,
+                name,
+                serviceName,
+                serviceIdentifier,
+                servicePlan,
+                tags,
+                credentials);
+        }
+    }
+}

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBinding.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBinding.java
@@ -5,6 +5,7 @@
 package com.sap.cloud.environment.servicebinding.api;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -99,4 +100,161 @@ public interface ServiceBinding
      */
     @Nonnull
     Map<String, Object> getCredentials();
+
+    /**
+     * Returns a <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     * but with the given {@code properties}.
+     * <p>
+     * <b>Note</b>: The given {@code properties} will affect {@link #getKeys()}, {@link #containsKey(String)}, and
+     * {@link #get(String)} <b>only</b>. All other methods will return the exact same values as this
+     * {@link ServiceBinding}.
+     * </p>
+     * <p>
+     * Example:
+     *
+     * <pre>
+     * ServiceBinding originalBinding;
+     * originalBinding.getKeys(); // ["old-key1", "old-key2"]
+     *
+     * ServiceBinding bindingWithArbitraryKey =
+     *     originalBinding.withProperties(Collections.singletonMap("new-key", "some value"));
+     * bindingWithArbitraryKey.getKeys(); // ["new-key"]
+     *
+     * originalBinding.getCredentials(); // {"key-1": "value-1", "key-2": "value-2"}
+     * ServiceBinding bindingWithCredentialsProperty =
+     *     originalBinding.withProperties(Collections.singletonMap("credentials", "some value"));
+     * bindingWithCredentialsProperty.getCredentials(); // {"key-1": "value-1", "key-2": "value-2"} <-- this has NOT been changed
+     * </pre>
+     * </p>
+     *
+     * @param properties
+     *            The properties to set. Supplying {@code null} is equivalent to supplying an empty {@link Map}.
+     * @return A <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     *         but with the given {@code properties}.
+     * @since 0.10.0
+     */
+    @Nonnull
+    default ServiceBinding withProperties( @Nullable final Map<String, Object> properties )
+    {
+        return DelegatingServiceBinding.builder(this).withProperties(properties).build();
+    }
+
+    /**
+     * Returns a <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     * but with the given {@code name}.
+     * <p>
+     * <b>Note</b>: The given {@code name} will affect {@link #getName()} <b>only</b>. All other methods will return the
+     * exact same values as this {@link ServiceBinding}.
+     * </p>
+     *
+     * @param name
+     *            The name to set.
+     * @return A <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     *         but with the given {@code name}.
+     * @since 0.10.0
+     */
+    @Nonnull
+    default ServiceBinding withName( @Nullable final String name )
+    {
+        return DelegatingServiceBinding.builder(this).withName(name).build();
+    }
+
+    /**
+     * Returns a <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     * but with the given {@code serviceName}.
+     * <p>
+     * <b>Note</b>: The given {@code serviceName} will affect {@link #getServiceName()} <b>only</b>. All other methods
+     * will return the exact same values as this {@link ServiceBinding}.
+     * </p>
+     *
+     * @param serviceName
+     *            The serviceName to set.
+     * @return A <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     *         but with the given {@code serviceName}.
+     * @since 0.10.0
+     */
+    @Nonnull
+    default ServiceBinding withServiceName( @Nullable final String serviceName )
+    {
+        return DelegatingServiceBinding.builder(this).withServiceName(serviceName).build();
+    }
+
+    /**
+     * Returns a <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     * but with the given {@code serviceIdentifier}.
+     * <p>
+     * <b>Note</b>: The given {@code serviceIdentifier} will affect {@link #getServiceIdentifier()} <b>only</b>. All
+     * other methods will return the exact same values as this {@link ServiceBinding}.
+     * </p>
+     *
+     * @param serviceIdentifier
+     *            The serviceIdentifier to set.
+     * @return A <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     *         but with the given {@code serviceIdentifier}.
+     * @since 0.10.0
+     */
+    @Nonnull
+    default ServiceBinding withServiceIdentifier( @Nullable final ServiceIdentifier serviceIdentifier )
+    {
+        return DelegatingServiceBinding.builder(this).withServiceIdentifier(serviceIdentifier).build();
+    }
+
+    /**
+     * Returns a <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     * but with the given {@code servicePlan}.
+     * <p>
+     * <b>Note</b>: The given {@code servicePlan} will affect {@link #getServicePlan()} <b>only</b>. All other methods
+     * will return the exact same values as this {@link ServiceBinding}.
+     * </p>
+     *
+     * @param servicePlan
+     *            The servicePlan to set.
+     * @return A <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     *         but with the given {@code servicePlan}.
+     * @since 0.10.0
+     */
+    @Nonnull
+    default ServiceBinding withServicePlan( @Nullable final String servicePlan )
+    {
+        return DelegatingServiceBinding.builder(this).withServicePlan(servicePlan).build();
+    }
+
+    /**
+     * Returns a <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     * but with the given {@code tags}.
+     * <p>
+     * <b>Note</b>: The given {@code tags} will affect {@link #getTags()} <b>only</b>. All other methods will return the
+     * exact same values as this {@link ServiceBinding}.
+     * </p>
+     *
+     * @param tags
+     *            The tags to set. Supplying {@code null} is equivalent to supplying an empty {@link List}.
+     * @return A <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     *         but with the given {@code tags}.
+     */
+    @Nonnull
+    default ServiceBinding withTags( @Nullable final List<String> tags )
+    {
+        return DelegatingServiceBinding.builder(this).withTags(tags).build();
+    }
+
+    /**
+     * Returns a <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     * but with the given {@code credentials}.
+     * <p>
+     * <b>Note</b>: The given {@code credentials} will affect {@link #getCredentials()} <b>only</b>. All other methods
+     * will return the exact same values as this {@link ServiceBinding}.
+     * </p>
+     *
+     * @param credentials
+     *            The credentials to set. Supplying {@code null} is equivalent to supplying an empty {@link Map}.
+     * @return A <b>NEW</b> {@link ServiceBinding} instance that contains the same values as this {@link ServiceBinding}
+     *         but with the given {@code credentials}.
+     * @since 0.10.0
+     */
+    @Nonnull
+    default ServiceBinding withCredentials( @Nullable final Map<String, Object> credentials )
+    {
+        return DelegatingServiceBinding.builder(this).withCredentials(credentials).build();
+    }
 }

--- a/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingTest.java
+++ b/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingTest.java
@@ -7,6 +7,7 @@ package com.sap.cloud.environment.servicebinding.api;
 import com.sap.cloud.environment.servicebinding.api.exception.UnsupportedPropertyTypeException;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
@@ -162,5 +163,158 @@ class DefaultServiceBindingTest
 
         assertThat(sut.getServiceName()).contains("foo");
         assertThat(sut.getServiceIdentifier()).contains(ServiceIdentifier.of("bar"));
+    }
+
+    @Test
+    void testEquals()
+    {
+        final DefaultServiceBinding firstSut = builderWithInitialValues().build();
+        final DefaultServiceBinding secondSut = builderWithInitialValues().build();
+
+        assertThat(firstSut).isEqualTo(secondSut).isNotSameAs(secondSut);
+
+        {
+            // different properties
+            final DefaultServiceBinding sut =
+                builderWithInitialValues(Collections.singletonMap("other-properties-key", "value")).build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut);
+        }
+
+        {
+            // different name
+            final DefaultServiceBinding sut = builderWithInitialValues().withName("other-name").build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut);
+        }
+
+        {
+            // different service name
+            final DefaultServiceBinding sut = builderWithInitialValues().withServiceName("other-service-name").build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut);
+        }
+
+        {
+            // different service identifier
+            final DefaultServiceBinding sut =
+                builderWithInitialValues()
+                    .withServiceIdentifier(ServiceIdentifier.of("other-service-identifier"))
+                    .build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut);
+        }
+
+        {
+            // different service plan
+            final DefaultServiceBinding sut = builderWithInitialValues().withServicePlan("other-service-plan").build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut);
+        }
+
+        {
+            // different tags
+            final DefaultServiceBinding sut =
+                builderWithInitialValues().withTags(Arrays.asList("other-tag1", "other-tag2")).build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut);
+        }
+
+        {
+            // different credentials
+            final DefaultServiceBinding sut =
+                builderWithInitialValues()
+                    .withCredentials(Collections.singletonMap("other-credentials-key", "value"))
+                    .build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut);
+        }
+    }
+
+    @Test
+    void testHashCode()
+    {
+        final DefaultServiceBinding firstSut = builderWithInitialValues().build();
+        final DefaultServiceBinding secondSut = builderWithInitialValues().build();
+
+        assertThat(firstSut.hashCode()).isEqualTo(secondSut.hashCode());
+
+        {
+            // different properties
+            final DefaultServiceBinding sut =
+                builderWithInitialValues(Collections.singletonMap("other-properties-key", "value")).build();
+
+            assertThat(sut.hashCode()).isNotEqualTo(firstSut.hashCode()).isNotEqualTo(secondSut.hashCode());
+        }
+
+        {
+            // different name
+            final DefaultServiceBinding sut = builderWithInitialValues().withName("other-name").build();
+
+            assertThat(sut.hashCode()).isNotEqualTo(firstSut.hashCode()).isNotEqualTo(secondSut.hashCode());
+        }
+
+        {
+            // different service name
+            final DefaultServiceBinding sut = builderWithInitialValues().withServiceName("other-service-name").build();
+
+            assertThat(sut.hashCode()).isNotEqualTo(firstSut.hashCode()).isNotEqualTo(secondSut.hashCode());
+        }
+
+        {
+            // different service identifier
+            final DefaultServiceBinding sut =
+                builderWithInitialValues()
+                    .withServiceIdentifier(ServiceIdentifier.of("other-service-identifier"))
+                    .build();
+
+            assertThat(sut.hashCode()).isNotEqualTo(firstSut.hashCode()).isNotEqualTo(secondSut.hashCode());
+        }
+
+        {
+            // different service plan
+            final DefaultServiceBinding sut = builderWithInitialValues().withServicePlan("other-service-plan").build();
+
+            assertThat(sut.hashCode()).isNotEqualTo(firstSut.hashCode()).isNotEqualTo(secondSut.hashCode());
+        }
+
+        {
+            // different tags
+            final DefaultServiceBinding sut =
+                builderWithInitialValues().withTags(Arrays.asList("other-tag1", "other-tag2")).build();
+
+            assertThat(sut.hashCode()).isNotEqualTo(firstSut.hashCode()).isNotEqualTo(secondSut.hashCode());
+        }
+
+        {
+            // different credentials
+            final DefaultServiceBinding sut =
+                builderWithInitialValues()
+                    .withCredentials(Collections.singletonMap("other-credentials-key", "value"))
+                    .build();
+
+            assertThat(sut.hashCode()).isNotEqualTo(firstSut.hashCode()).isNotEqualTo(secondSut.hashCode());
+        }
+    }
+
+    @Nonnull
+    private static DefaultServiceBinding.TerminalBuilder builderWithInitialValues()
+    {
+        return builderWithInitialValues(Collections.singletonMap("initial-properties-key", "value"));
+    }
+
+    @Nonnull
+    private static DefaultServiceBinding.TerminalBuilder builderWithInitialValues(
+        @Nonnull final Map<String, Object> properties )
+    {
+        return DefaultServiceBinding
+            .builder()
+            .copy(properties)
+            .withName("initial-name")
+            .withServiceName("initial-service-name")
+            .withServiceIdentifier(ServiceIdentifier.of("initial-service-identifier"))
+            .withServicePlan("initial-service-plan")
+            .withTags(Arrays.asList("initial-tag1", "initial-tag2"))
+            .withCredentials(Collections.singletonMap("initial-credentials-key", "value"));
     }
 }

--- a/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/DelegatingServiceBindingTest.java
+++ b/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/DelegatingServiceBindingTest.java
@@ -1,0 +1,608 @@
+/*
+ * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
+ */
+
+package com.sap.cloud.environment.servicebinding.api;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DelegatingServiceBindingTest
+{
+    @Test
+    void testGetKeysDelegation()
+    {
+        final Map<String, Object> delegateProperties = new HashMap<>();
+        delegateProperties.put("delegate-key1", "foo");
+        delegateProperties.put("delegate-key2", "bar");
+        final DefaultServiceBinding delegate = spy(DefaultServiceBinding.builder().copy(delegateProperties).build());
+
+        final Map<String, Object> overwrittenProperties = new HashMap<>();
+        overwrittenProperties.put("overwritten-key1", "baz");
+        overwrittenProperties.put("overwritten-key2", "qux");
+
+        final ServiceBinding sutWithoutProperties =
+            DelegatingServiceBinding.builder(delegate).withProperties(null).build();
+        final ServiceBinding sutWithProperties =
+            DelegatingServiceBinding.builder(delegate).withProperties(overwrittenProperties).build();
+        final ServiceBinding sutWithEmptyProperties =
+            DelegatingServiceBinding.builder(delegate).withProperties(new HashMap<>()).build();
+        final ServiceBinding sutThatDelegates = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(delegate.getKeys()).containsExactlyInAnyOrderElementsOf(delegateProperties.keySet());
+        verify(delegate, times(1)).getKeys();
+
+        assertThat(sutWithoutProperties.getKeys()).isEmpty();
+        assertThat(sutWithProperties.getKeys()).containsExactlyInAnyOrderElementsOf(overwrittenProperties.keySet());
+        assertThat(sutWithEmptyProperties.getKeys()).isEmpty();
+        assertThat(sutThatDelegates.getKeys()).containsExactlyInAnyOrderElementsOf(delegateProperties.keySet());
+        verify(delegate, times(2)).getKeys();
+    }
+
+    @Test
+    void testWithPropertiesCreatesDeepCopy()
+    {
+        final Map<String, Object> passedProperties = new HashMap<>();
+        passedProperties.put("string", "string");
+
+        final List<Object> nestedList = new ArrayList<>();
+        nestedList.add("item-1");
+        nestedList.add(Arrays.asList("subitem-1", "subitem-2"));
+        nestedList.add(Collections.singletonMap("key", "value"));
+        passedProperties.put("list", nestedList);
+
+        final Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("string", "string");
+        nestedMap.put("list", Arrays.asList("item-1", "item-2"));
+        nestedMap.put("map", Collections.singletonMap("key", "value"));
+        passedProperties.put("map", nestedMap);
+
+        final ServiceBinding sut =
+            DelegatingServiceBinding.builder(mock(ServiceBinding.class)).withProperties(passedProperties).build();
+
+        assertThat(sut.get("string")).contains("string");
+        assertThat(sut.get("list"))
+            .isNotEmpty()
+            .get()
+            .asList()
+            .containsExactly(
+                "item-1",
+                Arrays.asList("subitem-1", "subitem-2"),
+                Collections.singletonMap("key", "value"));
+        assertThat(sut.get("map"))
+            .isNotEmpty()
+            .get()
+            .asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class))
+            .containsEntry("string", "string")
+            .containsEntry("list", Arrays.asList("item-1", "item-2"))
+            .containsEntry("map", Collections.singletonMap("key", "value"));
+
+        // modify the original map
+        passedProperties.put("string", "modified-string");
+        passedProperties.remove("list");
+        nestedMap.remove("map");
+
+        assertThat(sut.get("string")).contains("string");
+        assertThat(sut.get("list"))
+            .isNotEmpty()
+            .get()
+            .asList()
+            .containsExactly(
+                "item-1",
+                Arrays.asList("subitem-1", "subitem-2"),
+                Collections.singletonMap("key", "value"));
+        assertThat(sut.get("map"))
+            .isNotEmpty()
+            .get()
+            .asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class))
+            .containsEntry("string", "string")
+            .containsEntry("list", Arrays.asList("item-1", "item-2"))
+            .containsEntry("map", Collections.singletonMap("key", "value"));
+    }
+
+    @Test
+    void testContainsKeyCallsGetKeys()
+    {
+        final ServiceBinding delegate = mock(ServiceBinding.class);
+        final ServiceBinding sut = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(sut).isInstanceOf(DelegatingServiceBinding.class);
+
+        final ServiceBinding spy = spy(sut);
+        when(spy.getKeys()).thenReturn(Collections.emptySet());
+
+        assertThat(spy.containsKey("foo")).isFalse();
+        verify(spy, times(1)).getKeys();
+    }
+
+    @Test
+    void testGetDelegation()
+    {
+        final Map<String, Object> delegateProperties = new HashMap<>();
+        delegateProperties.put("delegate-key", "foo");
+        final DefaultServiceBinding delegate = spy(DefaultServiceBinding.builder().copy(delegateProperties).build());
+
+        final Map<String, Object> overwrittenProperties = new HashMap<>();
+        overwrittenProperties.put("overwritten-key", "bar");
+
+        final ServiceBinding sutWithoutProperties =
+            DelegatingServiceBinding.builder(delegate).withProperties(null).build();
+        final ServiceBinding sutWithProperties =
+            DelegatingServiceBinding.builder(delegate).withProperties(overwrittenProperties).build();
+        final ServiceBinding sutWithEmptyProperties =
+            DelegatingServiceBinding.builder(delegate).withProperties(new HashMap<>()).build();
+        final ServiceBinding sutThatDelegates = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(delegate.get("delegate-key")).contains("foo");
+        assertThat(delegate.get("overwritten-key")).isEmpty();
+        verify(delegate, times(1)).get(eq("delegate-key"));
+        verify(delegate, times(1)).get(eq("overwritten-key"));
+
+        assertThat(sutWithoutProperties.get("delegate-key")).isEmpty();
+        assertThat(sutWithoutProperties.get("overwritten-key")).isEmpty();
+
+        assertThat(sutWithProperties.get("delegate-key")).isEmpty();
+        assertThat(sutWithProperties.get("overwritten-key")).contains("bar");
+
+        assertThat(sutWithEmptyProperties.get("delegate-key")).isEmpty();
+        assertThat(sutWithEmptyProperties.get("overwritten-key")).isEmpty();
+
+        assertThat(sutThatDelegates.get("delegate-key")).contains("foo");
+        assertThat(sutThatDelegates.get("overwritten-key")).isEmpty();
+        verify(delegate, times(2)).get(eq("delegate-key"));
+        verify(delegate, times(2)).get(eq("overwritten-key"));
+    }
+
+    @Test
+    void testGetNameDelegation()
+    {
+        final ServiceBinding delegate = mock(ServiceBinding.class);
+        when(delegate.getName()).thenReturn(Optional.of("delegate-name"));
+
+        final ServiceBinding sutWithoutName = DelegatingServiceBinding.builder(delegate).withName(null).build();
+        final ServiceBinding sutWithName =
+            DelegatingServiceBinding.builder(delegate).withName("overwritten-name").build();
+        final ServiceBinding sutThatDelegates = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(delegate.getName()).contains("delegate-name");
+        verify(delegate, times(1)).getName();
+
+        assertThat(sutWithoutName.getName()).isEmpty();
+        assertThat(sutWithName.getName()).contains("overwritten-name");
+        assertThat(sutThatDelegates.getName()).contains("delegate-name");
+        verify(delegate, times(2)).getName();
+    }
+
+    @Test
+    void testGetServiceNameDelegation()
+    {
+        final ServiceBinding delegate = mock(ServiceBinding.class);
+        when(delegate.getServiceName()).thenReturn(Optional.of("delegate-service-name"));
+
+        final ServiceBinding sutWithoutServiceName =
+            DelegatingServiceBinding.builder(delegate).withServiceName(null).build();
+        final ServiceBinding sutWithServiceName =
+            DelegatingServiceBinding.builder(delegate).withServiceName("overwritten-service-name").build();
+        final ServiceBinding sutThatDelegates = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(delegate.getServiceName()).contains("delegate-service-name");
+        verify(delegate, times(1)).getServiceName();
+
+        assertThat(sutWithoutServiceName.getServiceName()).isEmpty();
+        assertThat(sutWithServiceName.getServiceName()).contains("overwritten-service-name");
+        assertThat(sutThatDelegates.getServiceName()).contains("delegate-service-name");
+        verify(delegate, times(2)).getServiceName();
+    }
+
+    @Test
+    void testGetServiceIdentifierDelegation()
+    {
+        final ServiceBinding delegate = mock(ServiceBinding.class);
+        when(delegate.getServiceIdentifier())
+            .thenReturn(Optional.of(ServiceIdentifier.of("delegate-service-identifier")));
+
+        final ServiceBinding sutWithoutServiceIdentifier =
+            DelegatingServiceBinding.builder(delegate).withServiceIdentifier(null).build();
+        final ServiceBinding sutWithServiceIdentifier =
+            DelegatingServiceBinding
+                .builder(delegate)
+                .withServiceIdentifier(ServiceIdentifier.of("overwritten-service-identifier"))
+                .build();
+        final ServiceBinding sutThatDelegates = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(delegate.getServiceIdentifier()).contains(ServiceIdentifier.of("delegate-service-identifier"));
+        verify(delegate, times(1)).getServiceIdentifier();
+
+        assertThat(sutWithoutServiceIdentifier.getServiceIdentifier()).isEmpty();
+        assertThat(sutWithServiceIdentifier.getServiceIdentifier())
+            .contains(ServiceIdentifier.of("overwritten-service-identifier"));
+        assertThat(sutThatDelegates.getServiceIdentifier())
+            .contains(ServiceIdentifier.of("delegate-service-identifier"));
+        verify(delegate, times(2)).getServiceIdentifier();
+    }
+
+    @Test
+    void testGetServicePlanDelegation()
+    {
+        final ServiceBinding delegate = mock(ServiceBinding.class);
+        when(delegate.getServicePlan()).thenReturn(Optional.of("delegate-service-plan"));
+
+        final ServiceBinding sutWithoutServicePlan =
+            DelegatingServiceBinding.builder(delegate).withServicePlan(null).build();
+        final ServiceBinding sutWithServicePlan =
+            DelegatingServiceBinding.builder(delegate).withServicePlan("overwritten-service-plan").build();
+        final ServiceBinding sutThatDelegates = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(delegate.getServicePlan()).contains("delegate-service-plan");
+        verify(delegate, times(1)).getServicePlan();
+
+        assertThat(sutWithoutServicePlan.getServicePlan()).isEmpty();
+        assertThat(sutWithServicePlan.getServicePlan()).contains("overwritten-service-plan");
+        assertThat(sutThatDelegates.getServicePlan()).contains("delegate-service-plan");
+        verify(delegate, times(2)).getServicePlan();
+    }
+
+    @Test
+    void testGetTagsDelegation()
+    {
+        final ServiceBinding delegate = mock(ServiceBinding.class);
+        when(delegate.getTags()).thenReturn(Arrays.asList("delegate-tag-1", "delegate-tag-2"));
+
+        final ServiceBinding sutWithoutTags = DelegatingServiceBinding.builder(delegate).withTags(null).build();
+        final ServiceBinding sutWithTags =
+            DelegatingServiceBinding
+                .builder(delegate)
+                .withTags(Arrays.asList("overwritten-tag-1", "overwritten-tag-2"))
+                .build();
+        final ServiceBinding sutWithEmptyTags =
+            DelegatingServiceBinding.builder(delegate).withTags(new ArrayList<>()).build();
+        final ServiceBinding sutThatDelegates = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(delegate.getTags()).containsExactlyInAnyOrder("delegate-tag-1", "delegate-tag-2");
+        verify(delegate, times(1)).getTags();
+
+        assertThat(sutWithoutTags.getTags()).isEmpty();
+        assertThat(sutWithTags.getTags()).containsExactlyInAnyOrder("overwritten-tag-1", "overwritten-tag-2");
+        assertThat(sutWithEmptyTags.getTags()).isEmpty();
+        assertThat(sutThatDelegates.getTags()).containsExactlyInAnyOrder("delegate-tag-1", "delegate-tag-2");
+        verify(delegate, times(2)).getTags();
+    }
+
+    @Test
+    void testWithTagsCreatesDeepCopy()
+    {
+        final List<String> passedTags = new ArrayList<>();
+        passedTags.add("tag-1");
+        passedTags.add("tag-2");
+
+        final ServiceBinding sut =
+            DelegatingServiceBinding.builder(mock(ServiceBinding.class)).withTags(passedTags).build();
+
+        assertThat(sut.getTags()).containsExactlyInAnyOrder("tag-1", "tag-2");
+
+        // modify the original list
+        passedTags.add("tag-3");
+        passedTags.remove("tag-1");
+
+        assertThat(sut.getTags()).containsExactlyInAnyOrder("tag-1", "tag-2");
+    }
+
+    @Test
+    void testGetCredentialsDelegation()
+    {
+        final Map<String, Object> delegateCredentials = new HashMap<>();
+        delegateCredentials.put("delegate-key1", "foo");
+        delegateCredentials.put("delegate-key2", "bar");
+        final ServiceBinding delegate =
+            spy(
+                DefaultServiceBinding
+                    .builder()
+                    .copy(Collections.emptyMap())
+                    .withCredentials(delegateCredentials)
+                    .build());
+
+        final Map<String, Object> overwrittenCredentials = new HashMap<>();
+        overwrittenCredentials.put("overwritten-key1", "baz");
+        overwrittenCredentials.put("overwritten-key2", "qux");
+
+        final ServiceBinding sutWithoutCredentials =
+            DelegatingServiceBinding.builder(delegate).withCredentials(null).build();
+        final ServiceBinding sutWithCredentials =
+            DelegatingServiceBinding.builder(delegate).withCredentials(overwrittenCredentials).build();
+        final ServiceBinding sutWithEmptyCredentials =
+            DelegatingServiceBinding.builder(delegate).withCredentials(new HashMap<>()).build();
+        final ServiceBinding sutThatDelegates = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(delegate.getCredentials()).containsExactlyInAnyOrderEntriesOf(delegateCredentials);
+        verify(delegate, times(1)).getCredentials();
+
+        assertThat(sutWithoutCredentials.getCredentials()).isEmpty();
+        assertThat(sutWithCredentials.getCredentials()).containsExactlyInAnyOrderEntriesOf(overwrittenCredentials);
+        assertThat(sutWithEmptyCredentials.getCredentials()).isEmpty();
+        assertThat(sutThatDelegates.getCredentials()).containsExactlyInAnyOrderEntriesOf(delegateCredentials);
+        verify(delegate, times(2)).getCredentials();
+    }
+
+    @Test
+    void testWithCredentialsCreatesDeepCopy()
+    {
+        final Map<String, Object> passedCredentials = new HashMap<>();
+        passedCredentials.put("string", "string");
+
+        final List<Object> nestedList = new ArrayList<>();
+        nestedList.add("item-1");
+        nestedList.add(Arrays.asList("subitem-1", "subitem-2"));
+        nestedList.add(Collections.singletonMap("key", "value"));
+        passedCredentials.put("list", nestedList);
+
+        final Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("string", "string");
+        nestedMap.put("list", Arrays.asList("item-1", "item-2"));
+        nestedMap.put("map", Collections.singletonMap("key", "value"));
+        passedCredentials.put("map", nestedMap);
+
+        final ServiceBinding sut =
+            DelegatingServiceBinding.builder(mock(ServiceBinding.class)).withCredentials(passedCredentials).build();
+
+        assertThat(sut.getCredentials().get("string")).isEqualTo("string");
+        assertThat(sut.getCredentials().get("list"))
+            .asList()
+            .isNotEmpty()
+            .containsExactly(
+                "item-1",
+                Arrays.asList("subitem-1", "subitem-2"),
+                Collections.singletonMap("key", "value"));
+        assertThat(sut.getCredentials().get("map"))
+            .asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class))
+            .containsEntry("string", "string")
+            .containsEntry("list", Arrays.asList("item-1", "item-2"))
+            .containsEntry("map", Collections.singletonMap("key", "value"));
+
+        // modify the original map
+        passedCredentials.put("string", "modified-string");
+        passedCredentials.remove("list");
+        nestedMap.remove("map");
+
+        assertThat(sut.getCredentials().get("string")).isEqualTo("string");
+        assertThat(sut.getCredentials().get("list"))
+            .asList()
+            .containsExactly(
+                "item-1",
+                Arrays.asList("subitem-1", "subitem-2"),
+                Collections.singletonMap("key", "value"));
+        assertThat(sut.getCredentials().get("map"))
+            .asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class))
+            .containsEntry("string", "string")
+            .containsEntry("list", Arrays.asList("item-1", "item-2"))
+            .containsEntry("map", Collections.singletonMap("key", "value"));
+    }
+
+    @Test
+    void testEquals()
+    {
+        final DefaultServiceBinding delegate =
+            DefaultServiceBinding
+                .builder()
+                .copy(Collections.singletonMap("delegate-properties-key", "value"))
+                .withName("delegate-name")
+                .withServiceName("delegate-service-name")
+                .withServiceIdentifier(ServiceIdentifier.of("delegate-service-identifier"))
+                .withServicePlan("delegate-service-plan")
+                .withTags(Arrays.asList("delegate-tag1", "delegate-tag2"))
+                .withCredentials(Collections.singletonMap("delegate-credentials-key", "value"))
+                .build();
+
+        final ServiceBinding firstSut = DelegatingServiceBinding.builder(delegate).build();
+        final ServiceBinding secondSut = DelegatingServiceBinding.builder(delegate).build();
+
+        assertThat(firstSut).isEqualTo(firstSut).isEqualTo(secondSut).isNotSameAs(secondSut).isNotEqualTo(delegate);
+
+        {
+            // overwrite properties
+            final ServiceBinding sut =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withProperties(Collections.singletonMap("overwritten-properties-key", "value"))
+                    .build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut).isNotEqualTo(delegate);
+        }
+
+        {
+            // overwrite name
+            final ServiceBinding sut = DelegatingServiceBinding.builder(delegate).withName("overwritten-name").build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut).isNotEqualTo(delegate);
+        }
+
+        {
+            // overwrite service name
+            final ServiceBinding sut =
+                DelegatingServiceBinding.builder(delegate).withServiceName("overwritten-service-name").build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut).isNotEqualTo(delegate);
+        }
+
+        {
+            // overwrite service identifier
+            final ServiceBinding sut =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withServiceIdentifier(ServiceIdentifier.of("overwritten-service-identifier"))
+                    .build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut).isNotEqualTo(delegate);
+        }
+
+        {
+            // overwrite service plan
+            final ServiceBinding sut =
+                DelegatingServiceBinding.builder(delegate).withServicePlan("overwritten-service-plan").build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut).isNotEqualTo(delegate);
+        }
+
+        {
+            // overwrite tags
+            final ServiceBinding sut =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withTags(Arrays.asList("overwritten-tag1", "overwritten-tag2"))
+                    .build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut).isNotEqualTo(delegate);
+        }
+
+        {
+            // overwrite credentials
+            final ServiceBinding sut =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withCredentials(Collections.singletonMap("overwritten-credentials-key", "value"))
+                    .build();
+
+            assertThat(sut).isNotEqualTo(firstSut).isNotEqualTo(secondSut).isNotEqualTo(delegate);
+        }
+    }
+
+    @Test
+    void testHashCode()
+    {
+        final DefaultServiceBinding delegate =
+            DefaultServiceBinding
+                .builder()
+                .copy(Collections.singletonMap("delegate-properties-key", "value"))
+                .withName("delegate-name")
+                .withServiceName("delegate-service-name")
+                .withServiceIdentifier(ServiceIdentifier.of("delegate-service-identifier"))
+                .withServicePlan("delegate-service-plan")
+                .withTags(Arrays.asList("delegate-tag1", "delegate-tag2"))
+                .withCredentials(Collections.singletonMap("delegate-credentials-key", "value"))
+                .build();
+
+        final ServiceBinding firstSut = DelegatingServiceBinding.builder(delegate).build();
+        final ServiceBinding secondSut = DelegatingServiceBinding.builder(delegate).build();
+
+        // the delegate hash code is different because the `properties` are a private field that
+        // are not accessible from within the `DelegatingServiceBinding` even though the implementation can
+        // (implicitly) delegate to them
+        assertThat(firstSut.hashCode()).isEqualTo(secondSut.hashCode()).isNotSameAs(delegate.hashCode());
+
+        {
+            // overwrite properties
+            final ServiceBinding sutWithSameProperties =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withProperties(Collections.singletonMap("delegate-properties-key", "value"))
+                    .build();
+            final ServiceBinding sutWithDifferentProperties =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withProperties(Collections.singletonMap("overwritten-properties-key", "value"))
+                    .build();
+
+            assertThat(sutWithSameProperties.hashCode())
+                .isNotEqualTo(sutWithDifferentProperties.hashCode())
+                .isNotEqualTo(firstSut.hashCode())
+                .isNotEqualTo(secondSut.hashCode())
+                // we CAN produce a hash collision by using the exact same property values as the delegate contains
+                .isEqualTo(delegate.hashCode());
+
+            assertThat(sutWithDifferentProperties.hashCode())
+                .isNotEqualTo(sutWithSameProperties.hashCode())
+                .isNotEqualTo(firstSut.hashCode())
+                .isNotEqualTo(secondSut.hashCode())
+                .isNotEqualTo(delegate.hashCode());
+        }
+
+        {
+            // overwrite name
+            final ServiceBinding sut = DelegatingServiceBinding.builder(delegate).withName("overwritten-name").build();
+
+            assertThat(sut.hashCode())
+                .isNotEqualTo(firstSut.hashCode())
+                .isNotEqualTo(secondSut.hashCode())
+                .isNotEqualTo(delegate.hashCode());
+        }
+
+        {
+            // overwrite service name
+            final ServiceBinding sut =
+                DelegatingServiceBinding.builder(delegate).withServiceName("overwritten-service-name").build();
+
+            assertThat(sut.hashCode())
+                .isNotEqualTo(firstSut.hashCode())
+                .isNotEqualTo(secondSut.hashCode())
+                .isNotEqualTo(delegate.hashCode());
+        }
+
+        {
+            // overwrite service identifier
+            final ServiceBinding sut =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withServiceIdentifier(ServiceIdentifier.of("overwritten-service-identifier"))
+                    .build();
+
+            assertThat(sut.hashCode())
+                .isNotEqualTo(firstSut.hashCode())
+                .isNotEqualTo(secondSut.hashCode())
+                .isNotEqualTo(delegate.hashCode());
+        }
+
+        {
+            // overwrite service plan
+            final ServiceBinding sut =
+                DelegatingServiceBinding.builder(delegate).withServicePlan("overwritten-service-plan").build();
+
+            assertThat(sut.hashCode())
+                .isNotEqualTo(firstSut.hashCode())
+                .isNotEqualTo(secondSut.hashCode())
+                .isNotEqualTo(delegate.hashCode());
+        }
+
+        {
+            // overwrite tags
+            final ServiceBinding sut =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withTags(Arrays.asList("overwritten-tag1", "overwritten-tag2"))
+                    .build();
+
+            assertThat(sut.hashCode())
+                .isNotEqualTo(firstSut.hashCode())
+                .isNotEqualTo(secondSut.hashCode())
+                .isNotEqualTo(delegate.hashCode());
+        }
+
+        {
+            // overwrite credentials
+            final ServiceBinding sut =
+                DelegatingServiceBinding
+                    .builder(delegate)
+                    .withCredentials(Collections.singletonMap("overwritten-credentials-key", "value"))
+                    .build();
+
+            assertThat(sut.hashCode())
+                .isNotEqualTo(firstSut.hashCode())
+                .isNotEqualTo(secondSut.hashCode())
+                .isNotEqualTo(delegate.hashCode());
+        }
+    }
+}


### PR DESCRIPTION
## Context

This PR introduces the _"wither"_ pattern in the `ServiceBinding` interface.
This pattern allows customers to quickly and easily obtain **new** `ServiceBinding` instances with "modified" values.

Example:

```java
ServiceBinding originalBinding;
originalBinding.getServiceIdentifier(); // "my-service"

ServiceBinding changedBinding = originalBinding.withServiceIdentifier(ServiceIdentifier.of("something-else"));
changedBinding.getServiceIdentifier(); // "something-else"

assertThat(originalBinding).isNotSameAs(changedBinding); // true
```

These newly created `ServiceBinding` instances use delegation so that superfluous copying of avioded.

### Feature Scope

- [x] Introduce API 
    - [x] Add default implementation

<details>
<summary><h3>Release Notes</h3></summary>

## Module: `java-core-api`

* Add new API to the `ServiceBinding` interface that allows for easy and convenient access to "changed" `ServiceBinding` instances. These new APIs (`with<X>(...)`) will create a NEW `ServiceBinding` instances that contain exactly the same values as the original instance but with just the provided property overwritten.

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] Feature scope is tested
- [ ] Feature scope is documented
- [x] Release notes are created
