### PR TITLE
Resolve service-identifier for user-provided service bindings

### DIFF
--- a/sap-vcap-services/src/main/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessor.java
+++ b/sap-vcap-services/src/main/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessor.java
@@ -4,28 +4,25 @@
 
 package com.sap.cloud.environment.servicebinding;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import javax.annotation.Nonnull;
-
+import com.sap.cloud.environment.servicebinding.api.DefaultServiceBinding;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import com.sap.cloud.environment.servicebinding.api.ServiceBindingAccessor;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
+import com.sap.cloud.environment.servicebinding.api.exception.ServiceBindingAccessException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sap.cloud.environment.servicebinding.api.DefaultServiceBinding;
-import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
-import com.sap.cloud.environment.servicebinding.api.ServiceBindingAccessor;
-import com.sap.cloud.environment.servicebinding.api.exception.ServiceBindingAccessException;
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * A {@link ServiceBindingAccessor} that is able to load {@link ServiceBinding}s from SAP's {@code VCAP_SERVICES}
@@ -123,26 +120,28 @@ public class SapVcapServicesServiceBindingAccessor implements ServiceBindingAcce
     }
 
     @Nonnull
-    protected
-        Collection<ServiceBinding>
+    private
+        List<ServiceBinding>
         toServiceBindings( @Nonnull final Map<String, Object> props, @Nonnull final String serviceName )
     {
+        final List<ServiceBinding> result = new ArrayList<>();
+        result.add(createServiceBinding(props, serviceName, serviceName));
+
         if( isUserProvided(serviceName) ) {
             final List<String> tags = getTagsFromProperties(props);
-            return tags.stream().map(tag -> createServiceBinding(props, serviceName, tag)).collect(Collectors.toList());
-        } else {
-            return Collections.singleton(createServiceBinding(props, serviceName, serviceName));
+            tags.forEach(tag -> result.add(createServiceBinding(props, serviceName, tag)));
         }
+        return result;
     }
 
-    protected boolean isUserProvided( @Nonnull final String serviceName )
+    private boolean isUserProvided( @Nonnull final String serviceName )
     {
         return "user-provided".equalsIgnoreCase(serviceName);
     }
 
     @SuppressWarnings( "unchecked" )
     @Nonnull
-    protected List<String> getTagsFromProperties( @Nonnull final Map<String, Object> properties )
+    private List<String> getTagsFromProperties( @Nonnull final Map<String, Object> properties )
     {
         final Object tags = properties.get("tags");
         if( !(tags instanceof List) ) {
@@ -157,7 +156,7 @@ public class SapVcapServicesServiceBindingAccessor implements ServiceBindingAcce
     }
 
     @Nonnull
-    protected ServiceBinding createServiceBinding(
+    private ServiceBinding createServiceBinding(
         @Nonnull final Map<String, Object> properties,
         @Nonnull final String serviceName,
         @Nonnull final String serviceIdentifier )

--- a/sap-vcap-services/src/main/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessor.java
+++ b/sap-vcap-services/src/main/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessor.java
@@ -150,7 +150,7 @@ public class SapVcapServicesServiceBindingAccessor implements ServiceBindingAcce
             return Collections.emptyList();
         }
         if( ((List<?>) tags).isEmpty() || !(((List<?>) tags).get(0) instanceof String) ) {
-            logger.debug("Empty or unexpected format for \"tags\" in service binding {}.", tags);
+            logger.debug("Empty or unexpected format for \"tags\" in service binding: {}.", tags);
             return Collections.emptyList();
         }
         return (List<String>) tags;

--- a/sap-vcap-services/src/test/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessorTest.java
+++ b/sap-vcap-services/src/test/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessorTest.java
@@ -32,7 +32,7 @@ class SapVcapServicesServiceBindingAccessorTest
 
         final List<ServiceBinding> serviceBindings = sut.getServiceBindings();
 
-        assertThat(serviceBindings.size()).isEqualTo(6);
+        assertThat(serviceBindings.size()).isEqualTo(9);
 
         assertContainsXsuaaBinding1(serviceBindings);
         assertContainsXsuaaBinding2(serviceBindings);
@@ -166,11 +166,11 @@ class SapVcapServicesServiceBindingAccessorTest
             new SapVcapServicesServiceBindingAccessor(environmentVariableReader);
 
         // first invocation
-        assertThat(sut.getServiceBindings().size()).isEqualTo(6);
+        assertThat(sut.getServiceBindings().size()).isEqualTo(9);
         assertThat(environmentVariableReader.getInvocations()).isEqualTo(1);
 
         // second invocation
-        assertThat(sut.getServiceBindings().size()).isEqualTo(6);
+        assertThat(sut.getServiceBindings().size()).isEqualTo(9);
         assertThat(environmentVariableReader.getInvocations()).isEqualTo(2);
     }
 

--- a/sap-vcap-services/src/test/resources/SapVcapServicesServiceBindingAccessorTest/FullVcapServices.json
+++ b/sap-vcap-services/src/test/resources/SapVcapServicesServiceBindingAccessorTest/FullVcapServices.json
@@ -41,5 +41,22 @@
                 "clientsecret": "destination-clientsecret-1"
             }
         }
+    ],
+    "user-provided":[
+        {
+            "label": "user-provided",
+            "name": "my-user-provided-service-without-tags",
+            "tags": []
+        },
+        {
+            "label": "user-provided",
+            "name": "my-user-provided-service-with-one-tag",
+            "tags": ["destination"]
+        },
+        {
+            "label": "user-provided",
+            "name": "my-user-provided-service-with-two-tags",
+            "tags": ["outbound-requests","destination"]
+        }
     ]
 }


### PR DESCRIPTION
## Context

[CAP identifies services bindings](https://cap.cloud.sap/docs/node.js/cds-connect#vcap_services) via name in bindings properties:
* name
* binding_name
* **tags**

We already support name matching by default. This PR tries to enable the "tags" use-case in addition.

### Feature Scope

- [x] For `"user-provided"` VCAP service bindings, create a `ServiceBinding` instance for every tag.


Example, service identifiers:
![image](https://github.com/SAP/btp-environment-variable-access/assets/22489773/01952ae7-e372-4e49-a2bd-942b649595df)


<details>
<summary><h3>Release Notes</h3></summary>

<TODO: Insert release notes>

</details>

### Definition of Done

- [ ] Feature scope is implemented
- [ ] Feature scope is tested
- [ ] Feature scope is documented
- [ ] Release notes are created
