### PR TITLE
Remove `ServiceIdentifier` attribute from `ServiceBinding` for `"user-provided"` instances

### DIFF
--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBinding.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBinding.java
@@ -108,11 +108,7 @@ public class DefaultServiceBinding implements ServiceBinding
     @Override
     public Optional<ServiceIdentifier> getServiceIdentifier()
     {
-        if( serviceIdentifier != null ) {
-            return Optional.of(serviceIdentifier);
-        }
-
-        return getServiceName().map(ServiceIdentifier::of);
+        return Optional.ofNullable(serviceIdentifier);
     }
 
     @Nonnull
@@ -251,6 +247,14 @@ public class DefaultServiceBinding implements ServiceBinding
          */
         @Nonnull
         TerminalBuilder withServiceIdentifier( @Nonnull final ServiceIdentifier serviceIdentifier );
+
+        /**
+         * Removes the {@link ServiceIdentifier} from the to-be-built {@link DefaultServiceBinding}.
+         *
+         * @return This {@link TerminalBuilder} instance.
+         */
+        @Nonnull
+        TerminalBuilder withoutServiceIdentifier();
 
         /**
          * Extracts the {@link ServiceIdentifier} of the bound service of the to-be-built {@link DefaultServiceBinding}

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingBuilder.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingBuilder.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -41,8 +42,9 @@ public class DefaultServiceBindingBuilder
     @Nullable
     private String serviceName;
 
+    @SuppressWarnings( "OptionalUsedAsFieldOrParameterType" )
     @Nullable
-    private ServiceIdentifier serviceIdentifier;
+    private Optional<ServiceIdentifier> serviceIdentifier;
 
     @Nullable
     private String servicePlan;
@@ -200,7 +202,15 @@ public class DefaultServiceBindingBuilder
     @Override
     public DefaultServiceBinding.TerminalBuilder withServiceIdentifier( @Nonnull ServiceIdentifier serviceIdentifier )
     {
-        this.serviceIdentifier = serviceIdentifier;
+        this.serviceIdentifier = Optional.of(serviceIdentifier);
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public DefaultServiceBinding.TerminalBuilder withoutServiceIdentifier()
+    {
+        this.serviceIdentifier = Optional.empty();
         return this;
     }
 
@@ -210,7 +220,7 @@ public class DefaultServiceBindingBuilder
     {
         final String maybeServiceIdentifier = extractString(key);
         if( maybeServiceIdentifier != null ) {
-            serviceIdentifier = ServiceIdentifier.of(maybeServiceIdentifier);
+            serviceIdentifier = Optional.of(ServiceIdentifier.of(maybeServiceIdentifier));
         }
 
         return this;
@@ -269,11 +279,17 @@ public class DefaultServiceBindingBuilder
     @Override
     public DefaultServiceBinding build()
     {
+        @SuppressWarnings( "OptionalAssignedToNull" )
+        final ServiceIdentifier identifier =
+            serviceIdentifier != null
+                ? serviceIdentifier.orElse(null)
+                : serviceName != null ? ServiceIdentifier.of(serviceName) : null;
+
         return new DefaultServiceBinding(
             map,
             name,
             serviceName,
-            serviceIdentifier,
+            identifier,
             servicePlan,
             tags == null ? Collections.emptyList() : tags,
             credentials == null ? Collections.emptyMap() : credentials);

--- a/sap-vcap-services/src/main/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessor.java
+++ b/sap-vcap-services/src/main/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessor.java
@@ -132,14 +132,19 @@ public class SapVcapServicesServiceBindingAccessor implements ServiceBindingAcce
         ServiceBinding
         toServiceBinding( @Nonnull final JSONObject jsonServiceBinding, @Nonnull final String serviceName )
     {
-        return DefaultServiceBinding
+        final DefaultServiceBinding.TerminalBuilder builder = DefaultServiceBinding
             .builder()
             .copy(jsonServiceBinding.toMap())
             .withNameKey("name")
             .withServiceName(serviceName)
             .withServicePlanKey("plan")
             .withTagsKey("tags")
-            .withCredentialsKey("credentials")
-            .build();
+            .withCredentialsKey("credentials");
+
+        if("user-provided".equalsIgnoreCase(serviceName)) {
+            builder.withoutServiceIdentifier();
+        }
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
## Context

We figured it would be counter-intuitive to have service identifiers `"user-provided"` for user-provided service bindings originating from BTP CF `VCAP_SERVICES` environment variable.

<details>
<summary><h3>Release Notes</h3></summary>

<TODO: Insert release notes>

</details>

### Definition of Done

- [ ] Feature scope is implemented
- [ ] Feature scope is tested
- [ ] Feature scope is documented
- [ ] Release notes are created
