### PR TITLE
Update Audit log service identifier

### DIFF
--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceIdentifier.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceIdentifier.java
@@ -39,7 +39,7 @@ public final class ServiceIdentifier
      * Foundry environment)</a> service.
      */
     @Nonnull
-    public static final ServiceIdentifier AUDIT_LOG = of("auditlog-management");
+    public static final ServiceIdentifier AUDIT_LOG_RETRIEVAL = of("auditlog-management");
 
     /**
      * Represents the <a href="https://api.sap.com/package/SAPCPWorkflowAPIs/all">SAP Workflow Service for Cloud


### PR DESCRIPTION
## Context

The [Audit log retrieval service](https://api.sap.com/api/CFAuditLogRetrievalAPI/overview) can only be used to read audit logs, there is a different internal service available for writing audit logs. This PR adjusts the service identifier of audit log to reflect this better.

<details>
<summary><h3>Release Notes</h3></summary>

## Module: `java-core-api`

* Update the service identifier for [Audit log retrieval service](https://api.sap.com/api/CFAuditLogRetrievalAPI/overview) from `ServiceIdentifier.AUDIT_LOG` to `ServiceIdentifier.AUDIT_LOG_RETRIEVAL`

</details>

### Definition of Done

- [x] Feature scope is implemented
- ~[ ] Feature scope is tested~
- ~[ ] Feature scope is documented~
- [x] Release notes are created
