### PR TITLE
fix: Reuse Compliance

### DIFF
--- a/.codestyle/intellij_copyright.xml
+++ b/.codestyle/intellij_copyright.xml
@@ -1,8 +1,0 @@
-<component name="CopyrightManager">
-    <copyright>
-        <option name="keyword"/>
-        <option name="myName" value="SAP SE"/>
-        <option name="notice"
-                value="Copyright (c) &amp;#36;today.year SAP SE or an SAP affiliate company. All rights reserved."/>
-    </copyright>
-</component>

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -36,5 +36,6 @@ Files:
     pom.xml
     **/pom.xml
     */src/*
+    */.scripts/*
 Copyright:  2022 SAP SE or an SAP affiliate company and BTP Environment for Java contributors
 License: Apache-2.0

--- a/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingAccessor.java
+++ b/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingAccessor.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.util.List;

--- a/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingAccessor.java
+++ b/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingAccessor.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.util.List;

--- a/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMerger.java
+++ b/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMerger.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.util.ArrayList;

--- a/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/SimpleServiceBindingCache.java
+++ b/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/SimpleServiceBindingCache.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.time.Duration;

--- a/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/exception/ServiceBindingAccessException.java
+++ b/api-parent/access-api/src/main/java/com/sap/cloud/environment/servicebinding/api/exception/ServiceBindingAccessException.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api.exception;
 
 import javax.annotation.Nonnull;

--- a/api-parent/access-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMergerTest.java
+++ b/api-parent/access-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceBindingMergerTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.util.ArrayList;

--- a/api-parent/access-api/src/test/java/com/sap/cloud/environment/servicebinding/api/SimpleServiceBindingCacheTest.java
+++ b/api-parent/access-api/src/test/java/com/sap/cloud/environment/servicebinding/api/SimpleServiceBindingCacheTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.time.Duration;

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/TypedListView.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/TypedListView.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.util.ArrayList;

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/TypedMapView.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/TypedMapView.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.util.Collections;

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/exception/KeyNotFoundException.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/exception/KeyNotFoundException.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api.exception;
 
 import javax.annotation.Nonnull;

--- a/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/exception/ValueCastException.java
+++ b/api-parent/consumption-api/src/main/java/com/sap/cloud/environment/servicebinding/api/exception/ValueCastException.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api.exception;
 
 import java.util.Optional;

--- a/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/TypedListViewTest.java
+++ b/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/TypedListViewTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.lang.reflect.Method;

--- a/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/TypedMapViewTest.java
+++ b/api-parent/consumption-api/src/test/java/com/sap/cloud/environment/servicebinding/api/TypedMapViewTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import java.lang.reflect.Method;

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBinding.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBinding.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import com.sap.cloud.environment.servicebinding.api.exception.UnsupportedPropertyTypeException;

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingBuilder.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingBuilder.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import com.sap.cloud.environment.servicebinding.api.exception.UnsupportedPropertyTypeException;

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBinding.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceBinding.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import javax.annotation.Nonnull;

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceIdentifier.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceIdentifier.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import javax.annotation.Nonnull;

--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/exception/UnsupportedPropertyTypeException.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/exception/UnsupportedPropertyTypeException.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api.exception;
 
 import javax.annotation.Nonnull;

--- a/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingTest.java
+++ b/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/DefaultServiceBindingTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import com.sap.cloud.environment.servicebinding.api.exception.UnsupportedPropertyTypeException;

--- a/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceIdentifierTest.java
+++ b/api-parent/core-api/src/test/java/com/sap/cloud/environment/servicebinding/api/ServiceIdentifierTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding.api;
 
 import org.junit.jupiter.api.Test;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/BindingMetadata.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/BindingMetadata.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.util.ArrayList;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/BindingMetadataFactory.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/BindingMetadataFactory.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/BindingProperty.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/BindingProperty.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.util.Objects;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/BindingPropertyFormat.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/BindingPropertyFormat.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import javax.annotation.Nonnull;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredDataParsingStrategy.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredDataParsingStrategy.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredParsingStrategy.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredParsingStrategy.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredPropertySetter.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredPropertySetter.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.util.HashMap;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredSecretKeyParsingStrategy.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredSecretKeyParsingStrategy.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredSecretRootKeyParsingStrategy.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/LayeredSecretRootKeyParsingStrategy.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessor.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;

--- a/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
+++ b/sap-service-operator/src/main/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessor.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import com.sap.cloud.environment.servicebinding.api.DefaultServiceBinding;

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/BindingMetadataFactoryTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/BindingMetadataFactoryTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import javax.annotation.Nonnull;

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredDataParsingStrategyTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredDataParsingStrategyTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredSecretKeyParsingStrategyTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredSecretKeyParsingStrategyTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredSecretRootKeyParsingStrategyTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/LayeredSecretRootKeyParsingStrategyTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessorTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorLayeredServiceBindingAccessorTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessorTest.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/SapServiceOperatorServiceBindingIoAccessorTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/TestResource.java
+++ b/sap-service-operator/src/test/java/com/sap/cloud/environment/servicebinding/TestResource.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;

--- a/sap-vcap-services/src/main/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessor.java
+++ b/sap-vcap-services/src/main/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessor.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.util.ArrayList;

--- a/sap-vcap-services/src/test/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessorTest.java
+++ b/sap-vcap-services/src/test/java/com/sap/cloud/environment/servicebinding/SapVcapServicesServiceBindingAccessorTest.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.util.Collection;

--- a/sap-vcap-services/src/test/java/com/sap/cloud/environment/servicebinding/TestResource.java
+++ b/sap-vcap-services/src/test/java/com/sap/cloud/environment/servicebinding/TestResource.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
- */
-
 package com.sap.cloud.environment.servicebinding;
 
 import java.io.IOException;


### PR DESCRIPTION
## Context

Fixes #199 

This PR fixes our reuse compliance status, which was degraded to _not compliant_ due to the introduction of our `.scripts/` folder (which was initially not covered by the `.reuse/dep5` file.
This is now fixed.

Additionally, this PR also removes the redundant (and outdated) copyright file headers from our java classes.