### PR TITLE
refactor: CVE Caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,8 +7,9 @@ on:
     branches: [ main ]
 
 env:
-  CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data/**
-  CVE_CACHE_KEY: "cve-cache"
+  # keep the below two variables in sync with the ones in .github/workflows/update-vulnerability-database.yaml
+  CVE_CACHE_KEY: cve-db
+  CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data
 
 jobs:
   build:
@@ -25,12 +26,13 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java-version }}
-      - name: Restore Vulnerabilities Database
-        id: restore-cve
+
+      - name: Restore CVE Database
         uses: actions/cache/restore@v4
         with:
-          key: ${{ env.CVE_CACHE_KEY }}
           path: ${{ env.CVE_CACHE_DIR }}
+          key: ${{ env.CVE_CACHE_KEY }}
+          fail-on-cache-miss: true
 
       - name: Build with Maven
         run: mvn clean install -Dgpg.skip --no-transfer-progress
@@ -40,10 +42,3 @@ jobs:
             echo -e "Following files need to be formatted: \n$(git diff --name-only)"
             exit 1
           fi
-
-      - name: Store Vulnerabilities Database
-        if: ${{ steps.restore-cve.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.CVE_CACHE_DIR }}
-          key: ${{ env.CVE_CACHE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,9 @@ on:
         default: minor
 
 env:
-  CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data/9.0/**
-  CVE_CACHE_KEY: "cve-cache"
+  # keep the below two variables in sync with the ones in .github/workflows/update-vulnerability-database.yaml
+  CVE_CACHE_KEY: cve-db
+  CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data
 
 jobs:
   release:
@@ -37,12 +38,13 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
-      - name: Restore Vulnerabilities Database
-        id: restore-cve
+
+      - name: Restore CVE Database
         uses: actions/cache/restore@v4
         with:
-          key: ${{ env.CVE_CACHE_KEY }}
           path: ${{ env.CVE_CACHE_DIR }}
+          key: ${{ env.CVE_CACHE_KEY }}
+          fail-on-cache-miss: true
 
       - name: Bump Version
         id: bump-version
@@ -52,13 +54,6 @@ jobs:
 
       - name: Build Project
         run: mvn clean install -P release -Dgpg.skip
-
-      - name: Store Vulnerabilities Database
-        if: ${{ steps.restore-cve.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.CVE_CACHE_DIR }}
-          key: ${{ env.CVE_CACHE_KEY }}
 
       - name: Commit Changes
         run: |

--- a/.github/workflows/update-vulnerability-database.yaml
+++ b/.github/workflows/update-vulnerability-database.yaml
@@ -1,15 +1,11 @@
 name: Update Vulnerability Database
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
   schedule:
     - cron: '17 5 * * *' # use a somewhat random time to avoid producing load spikes on the GH actions infrastructure
 
 env:
-  CVE_CACHE_REF: refs/heads/main
   CVE_CACHE_KEY: cve-db
   CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data
 
@@ -20,9 +16,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.CVE_CACHE_REF }}
-
       - name: Restore Existing Cache
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/update-vulnerability-database.yaml
+++ b/.github/workflows/update-vulnerability-database.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run Maven Plugin
         run: |
-          mvn org.owasp:dependency-check-maven:update-only
+          mvn org.owasp:dependency-check-maven:update-only -DnvdMaxRetryCount=10 -DnvdApiDelay=15000 -DconnectionTimeout=60000
 
       - name: Cache CVE Database
         uses: actions/cache/save@v4

--- a/.github/workflows/update-vulnerability-database.yaml
+++ b/.github/workflows/update-vulnerability-database.yaml
@@ -23,6 +23,12 @@ jobs:
         with:
           ref: ${{ env.CVE_CACHE_REF }}
 
+      - name: Restore Existing Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CVE_CACHE_DIR }}
+          key: ${{ env.CVE_CACHE_KEY }}
+
       - name: Delete Cache
         run: |
           CACHE_IDS=$(gh cache list --key "${CVE_CACHE_KEY}" --ref "${CVE_CACHE_REF}" --json id | jq -r '.[] | .id')

--- a/.github/workflows/update-vulnerability-database.yaml
+++ b/.github/workflows/update-vulnerability-database.yaml
@@ -22,6 +22,10 @@ jobs:
           path: ${{ env.CVE_CACHE_DIR }}
           key: ${{ env.CVE_CACHE_KEY }}
 
+      - name: Run Maven Plugin
+        run: |
+          mvn org.owasp:dependency-check-maven:update-only -DnvdMaxRetryCount=10 -DnvdApiDelay=15000 -DconnectionTimeout=60000
+
       - name: Delete Cache
         run: |
           CACHE_IDS=$(gh cache list --key "${CVE_CACHE_KEY}" --ref "${CVE_CACHE_REF}" --json id | jq -r '.[] | .id')
@@ -31,10 +35,6 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Maven Plugin
-        run: |
-          mvn org.owasp:dependency-check-maven:update-only -DnvdMaxRetryCount=10 -DnvdApiDelay=15000 -DconnectionTimeout=60000
 
       - name: Cache CVE Database
         uses: actions/cache/save@v4

--- a/.github/workflows/update-vulnerability-database.yaml
+++ b/.github/workflows/update-vulnerability-database.yaml
@@ -1,6 +1,9 @@
 name: Update Vulnerability Database
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '17 5 * * *' # use a somewhat random time to avoid producing load spikes on the GH actions infrastructure

--- a/.github/workflows/update-vulnerability-database.yaml
+++ b/.github/workflows/update-vulnerability-database.yaml
@@ -1,0 +1,42 @@
+name: Update Vulnerability Database
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 5 * * *' # use a somewhat random time to avoid producing load spikes on the GH actions infrastructure
+
+env:
+  CVE_CACHE_REF: refs/heads/main
+  CVE_CACHE_KEY: cve-db
+  CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data
+
+jobs:
+  update-vulnerability-database:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CVE_CACHE_REF }}
+
+      - name: Delete Cache
+        run: |
+          CACHE_IDS=$(gh cache list --key "${CVE_CACHE_KEY}" --ref "${CVE_CACHE_REF}" --json id | jq -r '.[] | .id')
+          for CACHE_ID in $CACHE_IDS; do
+              echo "Deleting cache with ID: $CACHE_ID"
+              gh cache delete --id "${CACHE_ID}"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Maven Plugin
+        run: |
+          mvn org.owasp:dependency-check-maven:update-only
+
+      - name: Cache CVE Database
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CVE_CACHE_DIR }}
+          key: ${{ env.CVE_CACHE_KEY }}
+

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <maven.version>3.8</maven.version>
         <java.failOnWarning>true</java.failOnWarning>
         <skipTests>false</skipTests>
+        <updateCveDatabase>false</updateCveDatabase>
         <project.rootdir>${project.basedir}</project.rootdir>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -249,6 +250,7 @@
                         <skipProvidedScope>true</skipProvidedScope>
                         <failBuildOnCVSS>7</failBuildOnCVSS>
                         <suppressionFile>.etc/suppression.xml</suppressionFile>
+                        <autoUpdate>${updateCveDatabase}</autoUpdate>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## Context

This PR refactors how the caching of the Vulnerability (i.e. CVE) database works.

Previously (without the suggested changes), we are trying to update the database **on every build pipeline run**.
This approach, however, leads to a dead lock due to (most probably) the matrix build we are using.

To fix this issue, we are now introducing one workflow (the `Update Vulnerabilities Database` one) that runs on a fixed schedule and replaces the existing GH actions cache with an updated version.
Build pipeline runs will then use this cache (or fail if the cache isn't present) and skip updating the vulnerability database.

This drastically increases the build pipeline runtime.

