### PR TITLE
feat: Add `ServiceIdentifier` for the XSUAA

### DIFF
--- a/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceIdentifier.java
+++ b/api-parent/core-api/src/main/java/com/sap/cloud/environment/servicebinding/api/ServiceIdentifier.java
@@ -15,6 +15,14 @@ public final class ServiceIdentifier
     private static final Map<String, ServiceIdentifier> INSTANCES = new ConcurrentHashMap<>();
 
     /**
+     * Represents the <a href=
+     * "https://help.sap.com/docs/btp/sap-business-technology-platform/what-is-sap-authorization-and-trust-management-service">SAP
+     * Extended Service for User and Account Authentication (XSUAA)</a>.
+     */
+    @Nonnull
+    public static final ServiceIdentifier XSUAA = of("xsuaa");
+
+    /**
      * Represents the <a href="https://api.sap.com/api/SAP_CP_CF_Connectivity_Destination/overview">SAP Destination
      * Service (Cloud Foundry)</a>.
      */


### PR DESCRIPTION
## Context

This PR adds a new `ServiceIdentifier` constant for the [SAP XSUAA service](https://help.sap.com/docs/btp/sap-business-technology-platform/what-is-sap-authorization-and-trust-management-service)

### Feature Scope

- [x] Add new `ServiceIdentifier` constant

<details>
<summary><h3>Release Notes</h3></summary>

### Module: `java-core-api`

* Add new `ServiceIdentifier` (`ServiceIdentifier.XSUAA`) for the [SAP XSUAA service](https://help.sap.com/docs/btp/sap-business-technology-platform/what-is-sap-authorization-and-trust-management-service).

</details>

### Definition of Done

- [x] Feature scope is implemented
- [x] ~Feature scope is tested~
- [x] ~Feature scope is documented~
- [x] Release notes are created
