### PR TITLE
refactor: CRON Job for Auto Merging Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,26 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "10:00"
+      time: "06:00"
       timezone: Etc/UCT
-    reviewers:
-      - "Johannes-Schneider"
     open-pull-requests-limit: 10
+    groups:
+      production-minor-patch:
+        dependency-type: "production"
+        update-types: [ "minor", "patch" ]
+        exclude-patterns:
+          - "*-plugin"
+      production-major:
+        dependency-type: "production"
+        update-types: [ "major" ]
+        exclude-patterns:
+          - "*-plugin"
+      plugins:
+        dependency-type: "production"
+        patterns:
+          - "*-plugin"
+      test:
+        dependency-type: "development"
     ignore:
       - dependency-name: "com.github.ekryd.sortpom:sortpom-maven-plugin" # newer versions require Java > 8
       - dependency-name: "net.revelc.code.formatter:formatter-maven-plugin" # newer versions require Java > 8

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -48,7 +48,7 @@ jobs:
             echo "[DEBUG] Approving and Merging PR #$PR_NUMBER"
           
             # check if PR is already approved
-            REVIEW_DECISION=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == $pr) | .reviewDecision' <<< "$PRS")
+            REVIEW_DECISION=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == ($pr | tonumber)) | .reviewDecision' <<< "$PRS")
             if [[ "$REVIEW_DECISION" == "APPROVED" ]]; then
               echo "[DEBUG] PR #$PR_NUMBER is already approved, skipping"
             else
@@ -57,7 +57,7 @@ jobs:
             fi
           
             # check if PR is already auto-mergeable
-            AUTO_MERGE_REQUEST=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == $pr) | .autoMergeRequest' <<< "$PRS")
+            AUTO_MERGE_REQUEST=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == ($pr | tonumber)) | .autoMergeRequest' <<< "$PRS")
             if [[ -n "$AUTO_MERGE_REQUEST" ]]; then
               echo "[DEBUG] PR #$PR_NUMBER is already auto-mergeable, skipping"
             else
@@ -66,7 +66,7 @@ jobs:
             fi
           
             # check if PR is behind, so we can instruct dependabot to rebase
-            MERGE_STATE_STATUS=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == $pr) | .mergeStateStatus' <<< "$PRS")
+            MERGE_STATE_STATUS=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == ($pr | tonumber)) | .mergeStateStatus' <<< "$PRS")
             if [[ "$MERGE_STATE_STATUS" == "BEHIND" ]]; then
               echo "[DEBUG] PR #$PR_NUMBER is behind, instructing dependabot to rebase"
               gh pr comment "$PR_NUMBER" --body "@dependabot rebase"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,9 +2,6 @@ name: dependabot merger
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: '17 09 * * *' # trigger daily at 09:17 a.m., as dependabot will create new PRs daily at 6:00 a.m.
 
@@ -25,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Approve and Merge PRs
-
         run: |
           PRS=$(gh pr list --app "dependabot" --state "open" --json number,title,autoMergeRequest,reviewDecision,mergeable,mergeStateStatus)
           PR_NUMBERS=

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -58,8 +58,7 @@ jobs:
           
             # check if PR is already auto-mergeable
             AUTO_MERGE_REQUEST=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == $pr) | .autoMergeRequest' <<< "$PRS")
-            echo "[DEBUG] PR #$PR_NUMBER autoMergeRequest: '$AUTO_MERGE_REQUEST'"
-            if [[ "$AUTO_MERGE_REQUEST" != "null" ]]; then
+            if [[ -n "$AUTO_MERGE_REQUEST" ]]; then
               echo "[DEBUG] PR #$PR_NUMBER is already auto-mergeable, skipping"
             else
               echo "[DEBUG] PR #$PR_NUMBER is not auto-mergeable yet, enabling auto-merge"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -58,6 +58,7 @@ jobs:
           
             # check if PR is already auto-mergeable
             AUTO_MERGE_REQUEST=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == $pr) | .autoMergeRequest' <<< "$PRS")
+            echo "[DEBUG] PR #$PR_NUMBER autoMergeRequest: '$AUTO_MERGE_REQUEST'"
             if [[ "$AUTO_MERGE_REQUEST" != "null" ]]; then
               echo "[DEBUG] PR #$PR_NUMBER is already auto-mergeable, skipping"
             else

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,41 +1,76 @@
 name: dependabot merger
 
 on:
+  workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+  schedule:
+    - cron: '17 09 * * *' # trigger daily at 09:17 a.m., as dependabot will create new PRs daily at 6:00 a.m.
 
+env:
+  DEPENDABOT_GROUPS: |
+    production-minor-patch group
+    plugins group
+    test group
+    github-actions group
 jobs:
-  review-pr:
+  review-prs:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' &&
-      github.event_name == 'pull_request' }}
     permissions:
       pull-requests: write
       contents: write
     steps:
-      - name: dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2.0.0
-        with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-      - name: setup git
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Approve and Merge PRs
         run: |
-          git config --global user.email "cloudsdk@sap.com"
-          git config --global user.name "SAP Cloud SDK"
-      - name: comment major updates
-        if : ${{ steps.metadata.outputs.update-type == 'version-update:semver-major' }}
-        run: |
-          gh pr comment $PR_URL --body "PR **not approved** because it includes a major update of a dependency"
-          gh pr edit $PR_URL --add-label "please review"
+          PRS=$(gh pr list --app "dependabot" --state "open" --json number,title,autoMergeRequest,reviewDecision,mergeable,mergeStateStatus)
+          PR_NUMBERS=
+          while IFS= read -r GROUP; do
+            if [[ -z "$GROUP" ]]; then
+              continue
+            fi
+          
+            MATCHES=$(jq -r --arg group "$GROUP" '.[] | select(.title | contains($group)) | .number' <<< "$PRS")
+            echo "[DEBUG] Found PRs for group '$GROUP': '$MATCHES'"
+          
+            PR_NUMBERS="$MATCHES"$'\n'"$PR_NUMBERS"
+          done <<< "${{ env.DEPENDABOT_GROUPS }}"
+          echo "[DEBUG] Approving and Merging following PRs: '$PR_NUMBERS'"
+          
+          while IFS= read -r PR_NUMBER; do
+            if [[ -z "$PR_NUMBER" ]]; then
+              continue
+            fi
+          
+            echo "[DEBUG] Approving and Merging PR #$PR_NUMBER"
+          
+            # check if PR is already approved
+            REVIEW_DECISION=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == $pr) | .reviewDecision' <<< "$PRS")
+            if [[ "$REVIEW_DECISION" == "APPROVED" ]]; then
+              echo "[DEBUG] PR #$PR_NUMBER is already approved, skipping"
+            else
+              echo "[DEBUG] PR #$PR_NUMBER is not approved yet, approving"
+              gh pr review "$PR_NUMBER" --approve
+            fi
+          
+            # check if PR is already auto-mergeable
+            AUTO_MERGE_REQUEST=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == $pr) | .autoMergeRequest' <<< "$PRS")
+            if [[ "$AUTO_MERGE_REQUEST" != "null" ]]; then
+              echo "[DEBUG] PR #$PR_NUMBER is already auto-mergeable, skipping"
+            else
+              echo "[DEBUG] PR #$PR_NUMBER is not auto-mergeable yet, enabling auto-merge"
+              gh pr merge "$PR_NUMBER" --auto --squash
+            fi
+          
+            # check if PR is behind, so we can instruct dependabot to rebase
+            MERGE_STATE_STATUS=$(jq -r --arg pr "$PR_NUMBER" '.[] | select(.number == $pr) | .mergeStateStatus' <<< "$PRS")
+            if [[ "$MERGE_STATE_STATUS" == "BEHIND" ]]; then
+              echo "[DEBUG] PR #$PR_NUMBER is behind, instructing dependabot to rebase"
+              gh pr comment "$PR_NUMBER" --body "@dependabot rebase"
+            fi
+          done <<< "$PR_NUMBERS"
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.CLOUD_SDK_AT_SAP_ALL_ACCESS_PAT }}
-      - name: approve and merge
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
-        run: |
-          gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.CLOUD_SDK_AT_SAP_ALL_ACCESS_PAT }}


### PR DESCRIPTION
This PR refactors our automated PR merging for Dependabot PRs in a way that the workflow is triggered on a schedule instead of triggering right after the PR creation.

The old approach has shown to be non-functioning as the workflow was triggered by an external user (i.e. Dependabot), which (we assume) prevented the workflow from accessing any our secrets.
As a consequence, the workflow always failed.

This updated approach does not run into that issue as the workflow is not triggered by an external user.
So we can safely access all of our secrets.

[Example workflow run](https://github.com/SAP/btp-environment-variable-access/actions/runs/8919732762/job/24496421045)
[Example merged PR](https://github.com/SAP/btp-environment-variable-access/pull/214/)

