### PR TITLE
chore: Set permissions for GH workflows explicitly

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,6 +11,9 @@ env:
   CVE_CACHE_KEY: cve-db
   CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data
 
+permissions:
+  contents: read # checks out code
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/fosstars-project-report.yml
+++ b/.github/workflows/fosstars-project-report.yml
@@ -12,6 +12,10 @@ env:
   CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data
   CVE_CACHE_REF: refs/heads/main
 
+permissions:
+  contents: write # needed for Fosstars Rating step
+  actions: write # needed for deleting/creating CVE cache
+
 jobs:
   create_fosstars_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ env:
   CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data
   MVN_CLI_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version -DskipTests
 
+permissions:
+  contents: read # uses PAT
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Context

- https://github.com/SAP/ai-sdk-java-backlog/issues/398

This PR explicitly sets the least required permissions for github workflows.

No runs to show because I cannot test release (for obvious reasons) or ci build (because it has not dispatch trigger). I could test the fosstar run but it is [still failing](https://github.com/SAP/btp-environment-variable-access/actions/runs/26453605833/job/77881134198#step:8:477) even though I updated [the relevant dependency](https://github.com/SAP/btp-environment-variable-access/blob/3ab2a332401cac1682ae0e09239f7631c30ec062/sap-spring-properties/pom.xml#L14) 🤔 The failure has nothing to do with this PR.

